### PR TITLE
Add StreamingClassOperatorResponse

### DIFF
--- a/src/Models/Common/ResourceStatus.cs
+++ b/src/Models/Common/ResourceStatus.cs
@@ -1,0 +1,22 @@
+﻿namespace Arcane.Operator.Models.Common;
+
+/// <summary>
+/// Represents stream status badge for Lens app.
+/// </summary>
+public enum ResourceStatus
+{
+    /// <summary>
+    /// The stream is in a ready state.
+    /// </summary>
+    READY,
+
+    /// <summary>
+    /// The stream is in an error state.
+    /// </summary>
+    ERROR,
+
+    /// <summary>
+    /// The stream is in a warning state.
+    /// </summary>
+    WARNING
+}

--- a/src/Models/StreamOperatorResponse.cs
+++ b/src/Models/StreamOperatorResponse.cs
@@ -1,30 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Arcane.Operator.Models.Common;
 using Arcane.Operator.Models.StreamStatuses.StreamStatus.V1Beta1;
 
 namespace Arcane.Operator.Models;
-
-/// <summary>
-/// Represents stream status badge for Lens app.
-/// </summary>
-public enum StreamStatusType
-{
-    /// <summary>
-    /// The stream is in a ready state.
-    /// </summary>
-    READY,
-
-    /// <summary>
-    /// The stream is in an error state.
-    /// </summary>
-    ERROR,
-
-    /// <summary>
-    /// The stream is in a warning state.
-    /// </summary>
-    WARNING
-}
 
 /// <summary>
 /// Possible stream states.
@@ -114,7 +94,7 @@ public class StreamOperatorResponse
             Kind = kind,
             Conditions = new[]
             {
-                new V1Beta1StreamCondition { Type = StreamStatusType.WARNING.ToString(), Status = "True" }
+                new V1Beta1StreamCondition { Type = ResourceStatus.WARNING.ToString(), Status = "True" }
             },
             Phase = StreamPhase.RESTARTING
         };
@@ -135,7 +115,7 @@ public class StreamOperatorResponse
             Namespace = nameSpace,
             Conditions = new[]
             {
-                new V1Beta1StreamCondition { Type = StreamStatusType.READY.ToString(), Status = "True" }
+                new V1Beta1StreamCondition { Type = ResourceStatus.READY.ToString(), Status = "True" }
             },
             Phase = StreamPhase.RUNNING
         };
@@ -156,7 +136,7 @@ public class StreamOperatorResponse
             Namespace = nameSpace,
             Conditions = new[]
             {
-                new V1Beta1StreamCondition { Type = StreamStatusType.READY.ToString(), Status = "True" }
+                new V1Beta1StreamCondition { Type = ResourceStatus.READY.ToString(), Status = "True" }
             },
             Phase = StreamPhase.RELOADING
         };
@@ -177,7 +157,7 @@ public class StreamOperatorResponse
             Kind = kind,
             Conditions = new[]
             {
-                new V1Beta1StreamCondition { Type = StreamStatusType.WARNING.ToString(), Status = "True" }
+                new V1Beta1StreamCondition { Type = ResourceStatus.WARNING.ToString(), Status = "True" }
             },
             Phase = StreamPhase.TERMINATING
         };
@@ -198,7 +178,7 @@ public class StreamOperatorResponse
             Namespace = nameSpace,
             Conditions = new[]
             {
-                new V1Beta1StreamCondition { Type = StreamStatusType.WARNING.ToString(), Status = "True" }
+                new V1Beta1StreamCondition { Type = ResourceStatus.WARNING.ToString(), Status = "True" }
             },
             Phase = StreamPhase.STOPPED
         };
@@ -222,7 +202,7 @@ public class StreamOperatorResponse
             Conditions = new[]
             {
                 new V1Beta1StreamCondition
-                    { Type = StreamStatusType.ERROR.ToString(), Status = "True", Message = message }
+                    { Type = ResourceStatus.ERROR.ToString(), Status = "True", Message = message }
             },
             Phase = StreamPhase.FAILED
         };
@@ -244,7 +224,7 @@ public class StreamOperatorResponse
             Namespace = nameSpace,
             Conditions = new[]
             {
-                new V1Beta1StreamCondition { Type = StreamStatusType.WARNING.ToString(), Status = "True" }
+                new V1Beta1StreamCondition { Type = ResourceStatus.WARNING.ToString(), Status = "True" }
             },
             Phase = StreamPhase.SUSPENDED
         };
@@ -266,7 +246,7 @@ public class StreamOperatorResponse
             Namespace = nameSpace,
             Conditions = new[]
             {
-                new V1Beta1StreamCondition { Type = StreamStatusType.ERROR.ToString(), Status = "True" }
+                new V1Beta1StreamCondition { Type = ResourceStatus.ERROR.ToString(), Status = "True" }
             },
             Phase = StreamPhase.FAILED
         };

--- a/src/Models/StreamingClassOperatorResponse.cs
+++ b/src/Models/StreamingClassOperatorResponse.cs
@@ -1,0 +1,128 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Arcane.Operator.Models.Common;
+using Arcane.Operator.Models.StreamStatuses.StreamStatus.V1Beta1;
+
+namespace Arcane.Operator.Models;
+
+/// <summary>
+/// Possible stream states.
+/// </summary>
+public enum StreamClassPhase
+{
+    /// <summary>
+    /// An initial state of the StreamClass object.
+    /// </summary>
+    INITIALIZING,
+
+    /// <summary>
+    /// A ready streaming class is ready to be used and new Streams of this class can be created.
+    /// </summary>
+    READY,
+    
+    /// <summary>
+    /// An error occured in stream class controller and new Streams of this class can not be created.
+    /// </summary>
+    FAILED,
+    
+    /// <summary>
+    /// The stream class is stopped and new Streams of this class can not be created.
+    /// </summary>
+    STOPPED
+}
+
+/// <summary>
+/// Contains response from stream operator that can be used by other services inside the application
+/// </summary>
+[ExcludeFromCodeCoverage(Justification = "Model")]
+public record StreamClassOperatorResponse
+{
+    /// <summary>
+    /// Affected StreamClass identifier
+    /// </summary>
+    public string Id { get; private init; }
+
+    /// <summary>
+    /// Affected StreamClass kind
+    /// </summary>
+    public string Kind { get; set; }
+
+    /// <summary>
+    /// Affected StreamClass namespace
+    /// </summary>
+    public string Namespace { get; set; }
+
+    /// <summary>
+    /// Latest observed state of the StreamClass object
+    /// </summary>
+    public IEnumerable<V1Beta1StreamCondition> Conditions { get; private init; }
+
+    /// <summary>
+    /// StreamClass livecycle phase
+    /// </summary>
+    public StreamClassPhase Phase { get; private set; }
+
+
+    /// <summary>
+    /// Creates a StreamOperatorResponse object for stream with specified identifier, setting it state to RUNNING 
+    /// </summary>
+    /// <param name="nameSpace">Kubernetes namespace</param>
+    /// <param name="kind">Affected stream class kind</param>
+    /// <param name="streamClassId">Affected stream class identifier</param>
+    public static StreamClassOperatorResponse Ready(string nameSpace, string kind, string streamClassId)
+    {
+        return new StreamClassOperatorResponse
+        {
+            Id = streamClassId,
+            Kind = kind,
+            Namespace = nameSpace,
+            Conditions = new[]
+            {
+                new V1Beta1StreamCondition { Type = ResourceStatus.READY.ToString(), Status = "True" }
+            },
+            Phase = StreamClassPhase.READY
+        };
+    }
+    
+    /// <summary>
+    /// Creates a StreamOperatorResponse object for stream with specified identifier, setting it state to RUNNING 
+    /// </summary>
+    /// <param name="nameSpace">Kubernetes namespace</param>
+    /// <param name="kind">Affected stream class kind</param>
+    /// <param name="streamClassId">Affected stream class identifier</param>
+    public static StreamClassOperatorResponse Failed(string nameSpace, string kind, string streamClassId)
+    {
+        return new StreamClassOperatorResponse
+        {
+            Id = streamClassId,
+            Kind = kind,
+            Namespace = nameSpace,
+            Conditions = new[]
+            {
+                new V1Beta1StreamCondition { Type = ResourceStatus.READY.ToString(), Status = "True" }
+            },
+            Phase = StreamClassPhase.FAILED
+        };
+    }
+
+    /// <summary>
+    /// Creates a StreamOperatorResponse object for stream with specified identifier, setting it state to RUNNING 
+    /// </summary>
+    /// <param name="nameSpace">Kubernetes namespace</param>
+    /// <param name="kind">Affected stream class kind</param>
+    /// <param name="streamClassId">Affected stream class identifier</param>
+    public static StreamClassOperatorResponse Stopped(string nameSpace, string kind, string streamClassId)
+    {
+        return new StreamClassOperatorResponse
+        {
+            Id = streamClassId,
+            Kind = kind,
+            Namespace = nameSpace,
+            Conditions = new[]
+            {
+                new V1Beta1StreamCondition { Type = ResourceStatus.READY.ToString(), Status = "True" }
+            },
+            Phase = StreamClassPhase.STOPPED
+        };
+    }
+}


### PR DESCRIPTION
Part of #8 

## Scope

Implemented:
- Added the `StreamingClassOperatorResponse` class

Additional changes:
- Extracted `ResourceStatus` to the `Arcane.Opeator.Models.Common` namespace

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.