### PR TITLE
Set up build pipelines for amd64/arm64 builds

### DIFF
--- a/.container/Dockerfile
+++ b/.container/Dockerfile
@@ -1,37 +1,47 @@
-﻿FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
-ARG NUGET_TOKEN
-ARG PROJECT_NAME
+﻿# The `platform` argument here is required, since dotnet-sdk crashes with segmentation fault 
+# in case of arm64 builds, see https://github.com/dotnet/dotnet-docker/issues/4225 for details
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+
+ARG INSTALL_DD_TRACER="true"
+ARG TRACER_VERSION="2.49.0"
+ARG TARGETARCH
 
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
 COPY src/*.csproj ./
-RUN dotnet nuget add source --username USERNAME --password $NUGET_TOKEN --store-password-in-clear-text --name github "https://nuget.pkg.github.com/SneaksAndData/index.json"
-RUN dotnet restore
+RUN dotnet_arch=$(test "$TARGETARCH" = "amd64" && echo "x64" || echo "$TARGETARCH") && \
+    dotnet restore --runtime "linux-$dotnet_arch"
 
 # Copy everything else and build
 COPY src/. ./
-RUN dotnet publish "$PROJECT_NAME.csproj" -c Release -o out
+RUN dotnet_arch=$(test "$TARGETARCH" = "amd64" && echo "x64" || echo "$TARGETARCH") && \
+    dotnet publish "Arcane.Operator.csproj" -c Release -o out --runtime "linux-$dotnet_arch"
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
-ARG TRACER_VERSION="2.48.0"
-ARG PROJECT_NAME
-ENV PROJECT_ASSEMBLY=$PROJECT_NAME
+
+ARG TRACER_VERSION="2.49.0"
+ARG INSTALL_DD_TRACER="true"
+ARG TARGETARCH
 
 RUN apt-get update -y && apt-get install -y curl jq
 
 # Download and install the Datadog Tracer
-RUN mkdir -p /opt/datadog \
-    && mkdir -p /var/log/datadog \
-    && curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb \
-    && dpkg -i ./datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb \
-    && rm ./datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb 
+RUN if [ -z "$INSTALL_DD_TRACER" ]; then \
+      echo "Datadog tracer installation skipped"; \
+    else \
+        mkdir -p /opt/datadog \
+        && echo $TARGETARCH \
+        && mkdir -p /var/log/datadog \
+        && curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_${TARGETARCH}.deb \
+        && dpkg -i ./datadog-dotnet-apm_${TRACER_VERSION}_${TARGETARCH}.deb \
+        && rm ./datadog-dotnet-apm_${TRACER_VERSION}_${TARGETARCH}.deb ; \
+    fi;
     
-
 WORKDIR /app
 COPY --from=build-env /app/out .
 
 USER app
 
-ENTRYPOINT "dotnet" "$PROJECT_ASSEMBLY.dll"
+ENTRYPOINT "dotnet" "Arcane.Operator.dll"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,8 @@ on:
     
 env:
   PROJECT_NAME: Arcane.Operator
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
   
 jobs:
   validate_commit:
@@ -16,27 +18,75 @@ jobs:
     if: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
-        
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: 8.0.x
-          
+
       - name: Restore dependencies
         run: dotnet clean && dotnet nuget locals all --clear && dotnet restore
-        
+
       - name: Build
         run: dotnet build --no-restore
-        
+
       - name: Test
         working-directory: ./test
         run: |
           dotnet add package coverlet.msbuild &&
           dotnet test ${PROJECT_NAME}.Tests.csproj --configuration Debug --runtime linux-x64 /p:CollectCoverage=true /p:CoverletOutput=Coverage/ /p:CoverletOutputFormat=lcov --logger GitHubActions
-          
+
       - name: Publish Code Coverage
         if: ${{ github.event_name == 'pull_request' && always() }}
         uses: romeovs/lcov-reporter-action@v0.3.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: ./test/Coverage/coverage.info
+  build_image:
+    name: Build Docker Image and Helm Charts
+    runs-on: ubuntu-latest
+    needs: [ validate_commit ]
+    if: ${{ always() && (needs.validate_commit.result == 'success' || needs.validate_commit.result == 'skipped') }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with: 
+          fetch-depth: 0
+      
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get project version
+        uses: SneaksAndData/github-actions/generate_version@v0.0.17
+        id: version
+          
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{steps.version.outputs.version}}
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.2.0
+        with:
+          use: true
+          platforms: linux/arm64,linux/amd64
+          
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: .
+          file: .container/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64,linux/amd64


### PR DESCRIPTION
Resolves #16 

## Scope

Implemented:
- The DataDog tracer installation is now optional.
- Multiarch build for the Arcane.Operator
- Added steps in the build actions to build and push docker image to GitHub container registry

**NOTE**: This PR only covers the container build. The Helm chart will be added in the next PR.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.