### PR TITLE
Add the 'v' letter to Arcane versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}},value=${{steps.version.outputs.version}}
+            type=semver,pattern={{version}},value=v${{steps.version.outputs.version}}
         
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.2.0


### PR DESCRIPTION
Implemented:
- Fix the image tag pattern `0.0.0` => `v0.0.0`

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.