### PR TITLE
Refactor the StreamClassRepository class

### DIFF
--- a/src/Extensions/JsonElementExtensions.cs
+++ b/src/Extensions/JsonElementExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.Json;
+using Akka.Util;
+using Akka.Util.Extensions;
+using Arcane.Operator.Models.StreamDefinitions;
+using Arcane.Operator.Models.StreamDefinitions.Base;
+
+namespace Arcane.Operator.Extensions;
+
+/// <summary>
+/// Extension methods for the JsonElement class
+/// </summary>
+public static class JsonElementExtensions
+{
+    /// <summary>
+    /// Deserialize the JsonElement to IStreamDefinition object and wrap it in an Option{IStreamDefinition} object
+    /// </summary>
+    /// <param name="jsonElement">Element to deserialize</param>
+    /// <returns></returns>
+    public static Option<IStreamDefinition> AsOptionalStreamDefinition(this JsonElement jsonElement) =>
+        jsonElement.Deserialize<StreamDefinition>().AsOption<IStreamDefinition>();
+}

--- a/src/Services/Base/IStreamClassRepository.cs
+++ b/src/Services/Base/IStreamClassRepository.cs
@@ -1,8 +1,10 @@
-using Arcane.Operator.Configurations;
+using System.Threading.Tasks;
+using Akka.Util;
+using Arcane.Operator.Models.StreamClass.Base;
 
 namespace Arcane.Operator.Services.Base;
 
 public interface IStreamClassRepository
 {
-    CustomResourceConfiguration Get(string nameSpace, string kind);
+    Task<Option<IStreamClass>> Get(string nameSpace, string streamDefinitionKind);
 }


### PR DESCRIPTION
Part of  #24

## Scope

Implemented:
- Refactored the `StreamDefinitionRepository` class to use asyncrchonious API
- Fixed return type of the `IStreamClassRepository.Get` method

Additional changes:
- Added the `AsOptionalStreamDefinition` extension method to avoid code duplication and unnecessary type casts

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.