### PR TITLE
Fix after integration tests (part 2)

### DIFF
--- a/.helm/templates/configmap-appsettings.yaml
+++ b/.helm/templates/configmap-appsettings.yaml
@@ -9,14 +9,14 @@ data:
     {
       "StreamingJobOperatorServiceConfiguration": {
         "MaxBufferCapacity": {{ .Values.settings.jobMaintenanceController.maxEventBufferCapacity }},
-        "Namespace": "{{ default .Release.Namespace .Values.settings.jobMaintenanceController.jobNamespace}}"
+        "Namespace": "{{ default .Release.Namespace .Values.settings.jobMaintenanceController.jobNamespace }}"
       },
       "StreamingJobMaintenanceServiceConfiguration": {
         "MaxBufferCapacity": {{ .Values.settings.streamClassController.maxEventBufferCapacity }},
         "Namespace": "{{ default .Release.Namespace .Values.settings.streamClassController.streamClassesNamespace }}"
       },
       "StreamClassOperatorServiceConfiguration": {
-        "Namespace": {{ default .Release.Namespace .Values.settings.streamClassController.streamClassesNamespace }},
+        "Namespace": "{{ default .Release.Namespace .Values.settings.streamClassController.streamClassesNamespace }}",
         "MaxBufferCapacity": 100,
         "ApiGroup": "streaming.sneaksanddata.com",
         "Version": "v1beta1",

--- a/src/Models/StreamClass/Base/IStreamClass.cs
+++ b/src/Models/StreamClass/Base/IStreamClass.cs
@@ -65,5 +65,5 @@ public interface IStreamClass : IKubernetesObject<V1ObjectMeta>
     /// </summary>
     /// <param name="propertyName">Name of the property to test</param>
     /// <returns></returns>
-    bool IsSecretField(string propertyName);
+    bool IsSecretRef(string propertyName);
 }

--- a/src/Models/StreamClass/V1Beta1StreamClass.cs
+++ b/src/Models/StreamClass/V1Beta1StreamClass.cs
@@ -64,9 +64,9 @@ public class V1Beta1StreamClass : IStreamClass
     /// <inheritdoc cref="IStreamClass.MaxBufferCapacity"/>
     public int MaxBufferCapacity => this.Spec.MaxBufferCapacity;
 
-    /// <inheritdoc cref="IStreamClass.IsSecretField"/>
-    public bool IsSecretField(string propertyName)
+    /// <inheritdoc cref="IStreamClass.IsSecretRef"/>
+    public bool IsSecretRef(string propertyName)
     {
-        return this.Spec?.SecretFields?.Contains(propertyName) ?? false;
+        return this.Spec?.SecretRefs?.Contains(propertyName) ?? false;
     }
 }

--- a/src/Models/StreamClass/V1Beta1StreamClassSpec.cs
+++ b/src/Models/StreamClass/V1Beta1StreamClassSpec.cs
@@ -46,6 +46,6 @@ public class V1Beta1StreamClassSpec
     /// Stream class buffer object max capacity.
     /// This value is dependent on the expected number of streams that will be created for this class.
     /// </summary>
-    [JsonPropertyName("secretFields")]
-    public List<string> SecretFields { get; set; }
+    [JsonPropertyName("secretRefs")]
+    public List<string> SecretRefs { get; set; }
 }

--- a/src/Models/StreamDefinitions/StreamDefinition.cs
+++ b/src/Models/StreamDefinitions/StreamDefinition.cs
@@ -70,7 +70,7 @@ public class StreamDefinition : IStreamDefinition
     /// <inheritdoc cref="IStreamDefinition"/>
     public IEnumerable<V1EnvFromSource> ToV1EnvFromSources(IStreamClass streamDefinition) =>
         this.Spec.EnumerateObject()
-            .Where(s => streamDefinition.IsSecretField(s.Name))
+            .Where(s => streamDefinition.IsSecretRef(s.Name))
             .Select(p => new V1EnvFromSource(secretRef: p.Value.Deserialize<V1SecretEnvSource>()));
 
     /// <summary>
@@ -95,7 +95,7 @@ public class StreamDefinition : IStreamDefinition
     private IEnumerable<KeyValuePair<string, string>> SpecToEnvironment(IStreamClass streamClass)
     {
         var newObj = this.Spec.Clone().Deserialize<Dictionary<string, object>>();
-        foreach (var property in this.Spec.EnumerateObject().Where(property => streamClass.IsSecretField(property.Name)))
+        foreach (var property in this.Spec.EnumerateObject().Where(property => streamClass.IsSecretRef(property.Name)))
         {
             newObj.Remove(property.Name);
         }

--- a/src/Models/StreamDefinitions/StreamDefinition.cs
+++ b/src/Models/StreamDefinitions/StreamDefinition.cs
@@ -10,13 +10,14 @@ using Arcane.Models.StreamingJobLifecycle;
 using Arcane.Operator.Models.StreamClass.Base;
 using Arcane.Operator.Models.StreamDefinitions.Base;
 using k8s.Models;
-using Snd.Sdk.Hosting;
 
 namespace Arcane.Operator.Models.StreamDefinitions;
 
 [ExcludeFromCodeCoverage(Justification = "Model")]
 public class StreamDefinition : IStreamDefinition
 {
+    private const string ENV_PREFIX = "STREAMCONTEXT__";
+
     /// <summary>
     /// Stream configuration
     /// </summary>
@@ -99,9 +100,10 @@ public class StreamDefinition : IStreamDefinition
         {
             newObj.Remove(property.Name);
         }
+
         return new KeyValuePair<string, string>[]
         {
-            new($"{EnvironmentExtensions.GetAssemblyVariablePrefix()}SPEC", JsonSerializer.Serialize(newObj))
+            new($"{ENV_PREFIX}SPEC", JsonSerializer.Serialize(newObj))
         };
     }
 
@@ -125,8 +127,8 @@ public class StreamDefinition : IStreamDefinition
     private Dictionary<string, string> SelfToEnvironment(bool backfill) =>
         new()
         {
-            { $"{EnvironmentExtensions.GetAssemblyVariablePrefix()}STREAM_ID", this.StreamId },
-            { $"{EnvironmentExtensions.GetAssemblyVariablePrefix()}STREAM_KIND", this.Kind },
-            { $"{EnvironmentExtensions.GetAssemblyVariablePrefix()}BACKFILL", backfill.ToString().ToLowerInvariant() }
+            { $"{ENV_PREFIX}STREAM_ID", this.StreamId },
+            { $"{ENV_PREFIX}STREAM_KIND", this.Kind },
+            { $"{ENV_PREFIX}BACKFILL", backfill.ToString().ToLowerInvariant() }
         };
 }


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-operator/issues/40

## Scope

Implemented:
- Fixed quotes in `appsettings.json`
- Added explicit default environment variable prefix


Additional changes:
- The method `IsSecretField` renamed to `IsSecretRef`

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.