### PR TITLE
Remove unused generic type arguments from StreamOperatorService

### DIFF
--- a/src/Services/Base/IStreamOperatorService.cs
+++ b/src/Services/Base/IStreamOperatorService.cs
@@ -4,7 +4,7 @@ using Akka.Streams.Dsl;
 
 namespace Arcane.Operator.Services.Base;
 
-public interface IStreamOperatorService<TStreamType>
+public interface IStreamOperatorService
 {
     /// <summary>
     /// Return graph that watches for job events and updates stream state accordingly

--- a/src/Services/Operator/StreamOperatorService.cs
+++ b/src/Services/Operator/StreamOperatorService.cs
@@ -17,29 +17,24 @@ using k8s;
 using k8s.Models;
 using Microsoft.Extensions.Logging;
 using Snd.Sdk.ActorProviders;
-using Snd.Sdk.Kubernetes.Base;
 using Snd.Sdk.Tasks;
 
 namespace Arcane.Operator.Services.Operator;
 
-public class StreamOperatorService<TStreamType> : IStreamOperatorService<TStreamType>
-    where TStreamType : IStreamDefinition
+public class StreamOperatorService: IStreamOperatorService
 {
     private const int parallelism = 1;
 
-    private readonly IKubeCluster kubeCluster;
-    private readonly ILogger<StreamOperatorService<TStreamType>> logger;
+    private readonly ILogger<StreamOperatorService> logger;
     private readonly IStreamingJobOperatorService operatorService;
     private readonly IStreamDefinitionRepository streamDefinitionRepository;
     private readonly IStreamClass streamClass;
 
-    public StreamOperatorService(IKubeCluster kubeCluster,
-        IStreamClass streamClass,
+    public StreamOperatorService(IStreamClass streamClass,
         IStreamingJobOperatorService operatorService,
         IStreamDefinitionRepository streamDefinitionRepository,
-        ILogger<StreamOperatorService<TStreamType>> logger)
+        ILogger<StreamOperatorService> logger)
     {
-        this.kubeCluster = kubeCluster;
         this.streamClass = streamClass;
         this.streamDefinitionRepository = streamDefinitionRepository;
         this.operatorService = operatorService;

--- a/src/Services/Operator/StreamOperatorService.cs
+++ b/src/Services/Operator/StreamOperatorService.cs
@@ -21,7 +21,7 @@ using Snd.Sdk.Tasks;
 
 namespace Arcane.Operator.Services.Operator;
 
-public class StreamOperatorService: IStreamOperatorService
+public class StreamOperatorService : IStreamOperatorService
 {
     private const int parallelism = 1;
 

--- a/src/Services/Operator/StreamOperatorServiceWorker.cs
+++ b/src/Services/Operator/StreamOperatorServiceWorker.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Akka.Streams;
-using Arcane.Operator.Models.StreamDefinitions;
 using Arcane.Operator.Services.Base;
 using Microsoft.Extensions.Logging;
 
@@ -14,14 +13,14 @@ public class StreamOperatorServiceWorker
 {
     private readonly ILogger<StreamOperatorServiceWorker> logger;
     private readonly IMaterializer materializer;
-    private readonly IStreamOperatorService<StreamDefinition> streamOperatorService;
+    private readonly IStreamOperatorService streamOperatorService;
     private readonly CancellationTokenSource cts;
     private Task streamExecutionTask;
     private string streamClassId;
 
     public StreamOperatorServiceWorker(
         ILogger<StreamOperatorServiceWorker> logger,
-        IStreamOperatorService<StreamDefinition> streamOperatorService,
+        IStreamOperatorService streamOperatorService,
         IMaterializer materializer)
     {
         this.logger = logger;

--- a/src/Services/Operator/StreamOperatorServiceWorkerFactory.cs
+++ b/src/Services/Operator/StreamOperatorServiceWorkerFactory.cs
@@ -6,7 +6,6 @@ using Arcane.Operator.Models.StreamDefinitions;
 using Arcane.Operator.Services.Base;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Snd.Sdk.Kubernetes.Base;
 
 namespace Arcane.Operator.Services.Operator;
 
@@ -15,17 +14,16 @@ public class StreamOperatorServiceWorkerFactory : IStreamOperatorServiceWorkerFa
 {
     private readonly ILoggerFactory loggerFactory;
     private readonly IMaterializer materializer;
-    private readonly IKubeCluster kubeCluster;
     private readonly IStreamingJobOperatorService jobOperatorService;
     private readonly IStreamDefinitionRepository streamDefinitionRepository;
 
-    public StreamOperatorServiceWorkerFactory(ILoggerFactory loggerFactory, IMaterializer materializer,
-        IKubeCluster kubeCluster, IStreamingJobOperatorService jobOperatorService,
+    public StreamOperatorServiceWorkerFactory(ILoggerFactory loggerFactory,
+        IMaterializer materializer,
+        IStreamingJobOperatorService jobOperatorService,
         IStreamDefinitionRepository streamDefinitionRepository)
     {
         this.loggerFactory = loggerFactory;
         this.materializer = materializer;
-        this.kubeCluster = kubeCluster;
         this.jobOperatorService = jobOperatorService;
         this.streamDefinitionRepository = streamDefinitionRepository;
     }
@@ -33,12 +31,11 @@ public class StreamOperatorServiceWorkerFactory : IStreamOperatorServiceWorkerFa
     /// <inheritdoc cref="IStreamOperatorServiceWorkerFactory.Create"/>
     public StreamOperatorServiceWorker Create(IStreamClass streamClass)
     {
-        var streamOperatorService = new StreamOperatorService<StreamDefinition>(
-            this.kubeCluster,
+        var streamOperatorService = new StreamOperatorService(
             streamClass,
             this.jobOperatorService,
             this.streamDefinitionRepository,
-            this.loggerFactory.CreateLogger<StreamOperatorService<StreamDefinition>>()
+            this.loggerFactory.CreateLogger<StreamOperatorService>()
         );
         return new StreamOperatorServiceWorker(
             this.loggerFactory.CreateLogger<StreamOperatorServiceWorker>(),

--- a/test/Services/StreamClassOperatorServiceTests.cs
+++ b/test/Services/StreamClassOperatorServiceTests.cs
@@ -140,7 +140,7 @@ public class StreamClassOperatorServiceTests : IClassFixture<ServiceFixture>, IC
             .AddSingleton(this.serviceFixture.MockStreamDefinitionRepository.Object)
             .AddSingleton<IStreamClassRepository, StreamClassRepository>()
             .AddMemoryCache()
-            .AddSingleton(this.loggerFixture.Factory.CreateLogger<StreamOperatorService<StreamDefinition>>())
+            .AddSingleton(this.loggerFixture.Factory.CreateLogger<StreamOperatorService>())
             .AddSingleton(this.loggerFixture.Factory.CreateLogger<StreamClassOperatorService>())
             .AddSingleton(this.loggerFixture.Factory)
             .AddSingleton(optionsMock.Object)

--- a/test/Services/StreamOperatorServiceTests.cs
+++ b/test/Services/StreamOperatorServiceTests.cs
@@ -80,7 +80,7 @@ public class StreamOperatorServiceTests : IClassFixture<ServiceFixture>, IClassF
 
         // Act
         var sp = this.CreateServiceProvider();
-        await sp.GetRequiredService<IStreamOperatorService<StreamDefinition>>()
+        await sp.GetRequiredService<IStreamOperatorService>()
             .GetStreamDefinitionEventsGraph(CancellationToken.None)
             .Run(this.akkaFixture.Materializer);
 
@@ -126,7 +126,7 @@ public class StreamOperatorServiceTests : IClassFixture<ServiceFixture>, IClassF
 
         // Act
         var sp = this.CreateServiceProvider();
-        await sp.GetRequiredService<IStreamOperatorService<StreamDefinition>>()
+        await sp.GetRequiredService<IStreamOperatorService>()
             .GetStreamDefinitionEventsGraph(CancellationToken.None)
             .Run(this.akkaFixture.Materializer);
 
@@ -163,7 +163,7 @@ public class StreamOperatorServiceTests : IClassFixture<ServiceFixture>, IClassF
 
         // Act
         var sp = this.CreateServiceProvider();
-        await sp.GetRequiredService<IStreamOperatorService<StreamDefinition>>()
+        await sp.GetRequiredService<IStreamOperatorService>()
             .GetStreamDefinitionEventsGraph(CancellationToken.None)
             .Run(this.akkaFixture.Materializer);
 
@@ -214,7 +214,7 @@ public class StreamOperatorServiceTests : IClassFixture<ServiceFixture>, IClassF
 
         // Act
         var sp = this.CreateServiceProvider();
-        await sp.GetRequiredService<IStreamOperatorService<StreamDefinition>>()
+        await sp.GetRequiredService<IStreamOperatorService>()
             .GetStreamDefinitionEventsGraph(CancellationToken.None)
             .Run(this.akkaFixture.Materializer);
 
@@ -248,7 +248,7 @@ public class StreamOperatorServiceTests : IClassFixture<ServiceFixture>, IClassF
 
         // Act
         var sp = this.CreateServiceProvider();
-        await sp.GetRequiredService<IStreamOperatorService<FailedStreamDefinition>>()
+        await sp.GetRequiredService<IStreamOperatorService>()
             .GetStreamDefinitionEventsGraph(CancellationToken.None)
             .Run(this.akkaFixture.Materializer);
 
@@ -282,7 +282,7 @@ public class StreamOperatorServiceTests : IClassFixture<ServiceFixture>, IClassF
         var exception = await Assert.ThrowsAnyAsync<Exception>(async () =>
         {
             var sp = this.CreateServiceProvider();
-            await sp.GetRequiredService<IStreamOperatorService<FailedStreamDefinition>>()
+            await sp.GetRequiredService<IStreamOperatorService>()
                 .GetStreamDefinitionEventsGraph(CancellationToken.None)
                 .Run(this.akkaFixture.Materializer);
         });
@@ -319,7 +319,7 @@ public class StreamOperatorServiceTests : IClassFixture<ServiceFixture>, IClassF
 
         // Act
         var sp = this.CreateServiceProvider();
-        await sp.GetRequiredService<IStreamOperatorService<StreamDefinition>>()
+        await sp.GetRequiredService<IStreamOperatorService>()
             .GetStreamDefinitionEventsGraph(CancellationToken.None)
             .Run(this.akkaFixture.Materializer);
 
@@ -349,8 +349,7 @@ public class StreamOperatorServiceTests : IClassFixture<ServiceFixture>, IClassF
             .AddSingleton(this.serviceFixture.MockStreamingJobOperatorService.Object)
             .AddSingleton(this.serviceFixture.MockStreamDefinitionRepository.Object)
             .AddSingleton(Mock.Of<IStreamClassRepository>())
-            .AddSingleton(this.loggerFixture.Factory.CreateLogger<StreamOperatorService<StreamDefinition>>())
-            .AddSingleton(this.loggerFixture.Factory.CreateLogger<StreamOperatorService<FailedStreamDefinition>>())
+            .AddSingleton(this.loggerFixture.Factory.CreateLogger<StreamOperatorService>())
             .AddSingleton(this.loggerFixture.Factory.CreateLogger<StreamDefinitionRepository>())
             .AddSingleton(this.serviceFixture.MockStreamingJobOperatorService.Object)
             .AddSingleton(optionsMock.Object)
@@ -367,8 +366,7 @@ public class StreamOperatorServiceTests : IClassFixture<ServiceFixture>, IClassF
                     StreamClassResourceKind = "StreamClass"
                 }
             })
-            .AddSingleton<IStreamOperatorService<StreamDefinition>, StreamOperatorService<StreamDefinition>>()
-            .AddSingleton<IStreamOperatorService<FailedStreamDefinition>, StreamOperatorService<FailedStreamDefinition>>()
+            .AddSingleton<IStreamOperatorService, StreamOperatorService>()
             .BuildServiceProvider();
     }
 }


### PR DESCRIPTION
Resolves #50

## Scope

Implemented:
- Remove unused generic type argument `TStreamType` from `IStreamOperatorService` and it's implementation.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.