### PR TITLE
Add the IMetricsReporter interface and it's implementation

### DIFF
--- a/src/Configurations/MetricsReporterConfiguration.cs
+++ b/src/Configurations/MetricsReporterConfiguration.cs
@@ -1,0 +1,11 @@
+﻿using Arcane.Operator.Services.Metrics;
+
+namespace Arcane.Operator.Configurations;
+
+/// <summary>
+/// Configuration for the <see cref="MetricsReporter"/> class.
+/// </summary>
+public class MetricsReporterConfiguration
+{
+    public MetricsPublisherActorConfiguration StreamClassStatusActorConfiguration { get; set; }
+};

--- a/src/Models/StreamingClassOperatorResponse.cs
+++ b/src/Models/StreamingClassOperatorResponse.cs
@@ -32,6 +32,24 @@ public enum StreamClassPhase
     STOPPED
 }
 
+
+/// <summary>
+/// The StreamClassPhase extension methods.
+/// </summary>
+public static class StreamClassPhaseExtensions
+{
+    /// <summary>
+    /// Returns True if the lifecycle phase is final.
+    /// </summary>
+    /// <param name="phase">Phase</param>
+    /// <returns></returns>
+    public static bool IsFinal(this StreamClassPhase phase)
+    {
+        return phase is StreamClassPhase.FAILED or StreamClassPhase.STOPPED;
+    }
+    
+}
+
 /// <summary>
 /// Contains response from stream operator that can be used by other services inside the application
 /// </summary>

--- a/src/Models/StreamingClassOperatorResponse.cs
+++ b/src/Models/StreamingClassOperatorResponse.cs
@@ -47,7 +47,6 @@ public static class StreamClassPhaseExtensions
     {
         return phase is StreamClassPhase.FAILED or StreamClassPhase.STOPPED;
     }
-    
 }
 
 /// <summary>

--- a/src/Services/Base/IMetricsReporter.cs
+++ b/src/Services/Base/IMetricsReporter.cs
@@ -1,0 +1,34 @@
+﻿using Arcane.Operator.Models;
+using Arcane.Operator.Services.Models;
+using k8s;
+using k8s.Models;
+
+namespace Arcane.Operator.Services.Base;
+
+/// <summary>
+/// Interface for reporting metrics.
+/// </summary>
+public interface IMetricsReporter
+{
+    /// <summary>
+    /// Report status metrics for a StreamClass object
+    /// </summary>
+    /// <param name="streamClass">StreamClassOperatorResponse object with StreamClass status information</param>
+    /// <returns>The same object for processing in the next stages of operator state machine.</returns>
+    StreamClassOperatorResponse ReportStatusMetrics(StreamClassOperatorResponse streamClass);
+
+    /// <summary>
+    /// Reports Count metric for a V1Job object
+    /// </summary>
+    /// <param name="jobEvent">Job event type and job object</param>
+    /// <returns>The same object for processing in the next stages of operator state machine.</returns>
+    (WatchEventType, V1Job) ReportTrafficMetrics((WatchEventType, V1Job) jobEvent);
+
+    /// <summary>
+    /// Reports Count metric for a Kubernetes custom resource object
+    /// </summary>
+    /// <param name="ev">Object event metadata</param>
+    /// <typeparam name="TResource">Type of custom resource, must be a Kubernetes object</typeparam>
+    /// <returns></returns>
+    ResourceEvent<TResource> ReportTrafficMetrics<TResource>(ResourceEvent<TResource> ev) where TResource : IKubernetesObject<V1ObjectMeta>;
+}

--- a/src/Services/Metrics/DeclaredMetrics.cs
+++ b/src/Services/Metrics/DeclaredMetrics.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using Arcane.Operator.Extensions;
+using Arcane.Operator.Models;
+using k8s;
+using k8s.Models;
+using Snd.Sdk.Helpers;
+
+namespace Arcane.Operator.Services.Metrics;
+
+public static class DeclaredMetrics
+{
+    /// <summary>
+    /// Prefix for metrics published by the Arcane Operator
+    /// </summary>
+    private const string TAG_PREFIX = "arcane.sneaksanddata.com";
+    public static string TrafficMetricName(this WatchEventType eventType) => $"objects.{eventType.ToString().ToLowerInvariant()}";
+
+    public static SortedDictionary<string, string> GetMetricsTags(this IKubernetesObject<V1ObjectMeta> job) => new()
+    {
+        { $"{TAG_PREFIX}/namespace", job.Namespace() },
+        { $"{TAG_PREFIX}/kind", job.Kind },
+        { $"{TAG_PREFIX}/name", job.Name() },
+    };
+
+    public static SortedDictionary<string, string> GetMetricsTags(this V1Job job) => new()
+    {
+        { $"{TAG_PREFIX}/namespace", job.Namespace() },
+        { $"{TAG_PREFIX}/kind", job.GetStreamKind() },
+        { $"{TAG_PREFIX}/streamId", job.GetStreamId() }
+    };
+
+    public static SortedDictionary<string, string> GetMetricsTags(this StreamClassOperatorResponse s) => new()
+    {
+        { $"{TAG_PREFIX}/namespace", s.StreamClass?.Namespace().ToLowerInvariant() },
+        { $"{TAG_PREFIX}/kindRef", CodeExtensions.CamelCaseToSnakeCase(s.StreamClass?.KindRef ?? "unknown") },
+        { $"{TAG_PREFIX}/kind", CodeExtensions.CamelCaseToSnakeCase(s.StreamClass?.Kind ?? "unknown") },
+        { $"{TAG_PREFIX}/phase", s.Phase.ToString().ToLowerInvariant() }
+    };
+}

--- a/src/Services/Metrics/MetricsReporter.cs
+++ b/src/Services/Metrics/MetricsReporter.cs
@@ -1,0 +1,60 @@
+﻿using Akka.Actor;
+using Arcane.Operator.Configurations;
+using Arcane.Operator.Models;
+using Arcane.Operator.Services.Base;
+using Arcane.Operator.Services.Metrics.Actors;
+using Arcane.Operator.Services.Models;
+using k8s;
+using k8s.Models;
+using Microsoft.Extensions.Options;
+using Snd.Sdk.Metrics.Base;
+
+namespace Arcane.Operator.Services.Metrics;
+
+/// <summary>
+/// The IMetricsReporter implementation.
+/// </summary>
+public class MetricsReporter : IMetricsReporter
+{
+    private readonly MetricsService metricsService;
+    private readonly IActorRef statusActor;
+
+    public MetricsReporter(MetricsService metricsService, ActorSystem actorSystem,
+        IOptions<MetricsReporterConfiguration> metricsReporterConfiguration)
+    {
+        this.metricsService = metricsService;
+        this.statusActor = actorSystem.ActorOf(Props.Create(() => new MetricsPublisherActor(
+                metricsReporterConfiguration.Value.StreamClassStatusActorConfiguration,
+                metricsService)),
+            nameof(MetricsPublisherActor));
+    }
+
+    /// <inheritdoc cref="IMetricsReporter.ReportStatusMetrics"/>
+    public StreamClassOperatorResponse ReportStatusMetrics(StreamClassOperatorResponse streamClass)
+    {
+        if (streamClass.Phase.IsFinal())
+        {
+            this.statusActor.Tell(new RemoveStreamClassMetricsMessage(streamClass.StreamClass.KindRef));
+        }
+        else
+        {
+            var msg = new AddStreamClassMetricsMessage(streamClass.StreamClass.KindRef, "stream_class", streamClass.GetMetricsTags());
+            this.statusActor.Tell(msg);
+        }
+        return streamClass;
+    }
+
+    /// <inheritdoc cref="IMetricsReporter.ReportTrafficMetrics"/>
+    public (WatchEventType, V1Job) ReportTrafficMetrics((WatchEventType, V1Job) jobEvent)
+    {
+        this.metricsService.Count(jobEvent.Item1.TrafficMetricName(), 1, jobEvent.Item2.GetMetricsTags());
+        return jobEvent;
+    }
+
+    /// <inheritdoc cref="IMetricsReporter.ReportTrafficMetrics"/>
+    public ResourceEvent<TResource> ReportTrafficMetrics<TResource>(ResourceEvent<TResource> ev) where TResource : IKubernetesObject<V1ObjectMeta>
+    {
+        this.metricsService.Count(ev.EventType.TrafficMetricName(), 1, ev.kubernetesObject.GetMetricsTags());
+        return ev;
+    }
+}


### PR DESCRIPTION
Part of #65

## Scope

Implemented:
- Metrics Reporter class which id responsible for reporting metrics from Arcane.Operator services.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.