### PR TITLE
Use the snake case for operator metrics

### DIFF
--- a/src/Configurations/MetricsReporterConfiguration.cs
+++ b/src/Configurations/MetricsReporterConfiguration.cs
@@ -7,5 +7,5 @@ namespace Arcane.Operator.Configurations;
 /// </summary>
 public class MetricsReporterConfiguration
 {
-    public MetricsPublisherActorConfiguration StreamClassStatusActorConfiguration { get; set; }
+    public MetricsPublisherActorConfiguration MetricsPublisherActorConfiguration { get; set; }
 };

--- a/src/Services/Metrics/DeclaredMetrics.cs
+++ b/src/Services/Metrics/DeclaredMetrics.cs
@@ -26,13 +26,13 @@ public static class DeclaredMetrics
     {
         { $"{TAG_PREFIX}/namespace", job.Namespace() },
         { $"{TAG_PREFIX}/kind", job.GetStreamKind() },
-        { $"{TAG_PREFIX}/streamId", job.GetStreamId() }
+        { $"{TAG_PREFIX}/stream_id", job.GetStreamId() }
     };
 
     public static SortedDictionary<string, string> GetMetricsTags(this StreamClassOperatorResponse s) => new()
     {
         { $"{TAG_PREFIX}/namespace", s.StreamClass?.Namespace().ToLowerInvariant() },
-        { $"{TAG_PREFIX}/kindRef", CodeExtensions.CamelCaseToSnakeCase(s.StreamClass?.KindRef ?? "unknown") },
+        { $"{TAG_PREFIX}/kind_ref", CodeExtensions.CamelCaseToSnakeCase(s.StreamClass?.KindRef ?? "unknown") },
         { $"{TAG_PREFIX}/kind", CodeExtensions.CamelCaseToSnakeCase(s.StreamClass?.Kind ?? "unknown") },
         { $"{TAG_PREFIX}/phase", s.Phase.ToString().ToLowerInvariant() }
     };

--- a/src/Services/Metrics/MetricsReporter.cs
+++ b/src/Services/Metrics/MetricsReporter.cs
@@ -24,7 +24,7 @@ public class MetricsReporter : IMetricsReporter
     {
         this.metricsService = metricsService;
         this.statusActor = actorSystem.ActorOf(Props.Create(() => new MetricsPublisherActor(
-                metricsReporterConfiguration.Value.StreamClassStatusActorConfiguration,
+                metricsReporterConfiguration.Value.MetricsPublisherActorConfiguration,
                 metricsService)),
             nameof(MetricsPublisherActor));
     }

--- a/test/Services/StreamClassOperatorServiceTests.cs
+++ b/test/Services/StreamClassOperatorServiceTests.cs
@@ -142,7 +142,7 @@ public class StreamClassOperatorServiceTests : IClassFixture<ServiceFixture>, IC
             .Returns(new CustomResourceConfiguration());
         var metricsReporterConfiguration = Options.Create(new MetricsReporterConfiguration
         {
-            StreamClassStatusActorConfiguration = new MetricsPublisherActorConfiguration
+            MetricsPublisherActorConfiguration = new MetricsPublisherActorConfiguration
             {
                 InitialDelay = TimeSpan.FromSeconds(30),
                 UpdateInterval = TimeSpan.FromSeconds(10)

--- a/test/Services/StreamOperatorServiceTests.cs
+++ b/test/Services/StreamOperatorServiceTests.cs
@@ -353,7 +353,7 @@ public class StreamOperatorServiceTests : IClassFixture<ServiceFixture>, IClassF
             .Returns(new CustomResourceConfiguration());
         var metricsReporterConfiguration = Options.Create(new MetricsReporterConfiguration
         {
-            StreamClassStatusActorConfiguration = new MetricsPublisherActorConfiguration
+            MetricsPublisherActorConfiguration = new MetricsPublisherActorConfiguration
             {
                 InitialDelay = TimeSpan.FromSeconds(30),
                 UpdateInterval = TimeSpan.FromSeconds(10)

--- a/test/Services/StreamingJobMaintenanceServiceTests.cs
+++ b/test/Services/StreamingJobMaintenanceServiceTests.cs
@@ -229,7 +229,7 @@ public class StreamingJobMaintenanceServiceTests : IClassFixture<ServiceFixture>
     {
         var metricsReporterConfiguration = Options.Create(new MetricsReporterConfiguration
         {
-            StreamClassStatusActorConfiguration = new MetricsPublisherActorConfiguration
+            MetricsPublisherActorConfiguration = new MetricsPublisherActorConfiguration
             {
                 InitialDelay = TimeSpan.FromSeconds(30),
                 UpdateInterval = TimeSpan.FromSeconds(10)


### PR DESCRIPTION
Part of #61 

## Scope

Implemented:
- Use the snake case for Operator metrics

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.