### PR TITLE
Fix the default application version

### DIFF
--- a/.helm/Chart.yaml
+++ b/.helm/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 0.0.0
 
-appVersion: "0.0.0"
+appVersion: 0.0.0


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-operator/issues/38

## Scope

Implemented:
- We need to remove quotes in the appVersion field since our `build_helm_chart` action [expects](https://github.com/SneaksAndData/github-actions/blob/de9bf39027977e2bbb90c61fa61a23cf13046b22/build_helm_chart/build_chart.sh#L20) the line `appVersion: 0.0.0` in Chart.yaml.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.
