### PR TITLE
Remove redundant return value from the IStreamDefinitionRepository.GettStreamDefinition object

### DIFF
--- a/src/Services/Base/IStreamDefinitionRepository.cs
+++ b/src/Services/Base/IStreamDefinitionRepository.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Akka.Util;
-using Arcane.Operator.Models.StreamClass.Base;
 using Arcane.Operator.Models.StreamDefinitions.Base;
 using Arcane.Operator.Models.StreamStatuses.StreamStatus.V1Beta1;
 
@@ -15,7 +14,7 @@ public interface IStreamDefinitionRepository : IReactiveResourceCollection<IStre
     /// <param name="kind">Stream definition kind to update</param>
     /// <param name="streamId">Stream identifier</param>
     /// <returns>IStreamDefinition or None, it it does not exit</returns>
-    public Task<(Option<IStreamClass>, Option<IStreamDefinition>)> GetStreamDefinition(string nameSpace, string kind,
+    public Task<Option<IStreamDefinition>> GetStreamDefinition(string nameSpace, string kind,
         string streamId);
 
     /// <summary>

--- a/src/Services/Repositories/StreamDefinitionRepository.cs
+++ b/src/Services/Repositories/StreamDefinitionRepository.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Akka;
@@ -8,12 +7,10 @@ using Akka.Streams.Dsl;
 using Akka.Util;
 using Arcane.Models.StreamingJobLifecycle;
 using Arcane.Operator.Extensions;
-using Arcane.Operator.Models.StreamClass.Base;
 using Arcane.Operator.Models.StreamDefinitions;
 using Arcane.Operator.Models.StreamDefinitions.Base;
 using Arcane.Operator.Models.StreamStatuses.StreamStatus.V1Beta1;
 using Arcane.Operator.Services.Base;
-using Arcane.Operator.Services.Commands;
 using Arcane.Operator.Services.Models;
 using Microsoft.Extensions.Logging;
 using Snd.Sdk.Kubernetes.Base;
@@ -36,13 +33,13 @@ public class StreamDefinitionRepository : IStreamDefinitionRepository
         this.streamClassRepository = streamClassRepository;
     }
 
-    public Task<(Option<IStreamClass>, Option<IStreamDefinition>)> GetStreamDefinition(string nameSpace, string kind, string streamId) =>
+    public Task<Option<IStreamDefinition>> GetStreamDefinition(string nameSpace, string kind, string streamId) =>
         this.streamClassRepository.Get(nameSpace, kind).FlatMap(crdConf =>
             {
                 if (crdConf is { HasValue: false })
                 {
                     this.logger.LogError("Failed to get configuration for kind {kind}", kind);
-                    return Task.FromResult((Option<IStreamClass>.None, Option<IStreamDefinition>.None));
+                    return Task.FromResult(Option<IStreamDefinition>.None);
                 }
 
                 return this.kubeCluster
@@ -52,7 +49,7 @@ public class StreamDefinitionRepository : IStreamDefinitionRepository
                         crdConf.Value.PluralNameRef,
                         nameSpace,
                         streamId,
-                        element => (crdConf, element.AsOptionalStreamDefinition()));
+                        element => element.AsOptionalStreamDefinition());
             }
         );
 

--- a/test/Services/StreamingJobMaintenanceServiceTests.cs
+++ b/test/Services/StreamingJobMaintenanceServiceTests.cs
@@ -73,7 +73,7 @@ public class StreamingJobMaintenanceServiceTests : IClassFixture<LoggerFixture>
         this.streamDefinitionRepositoryMock
             .Setup(s => s.GetStreamDefinition(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(() =>
-                definitionExists ? (Mock.Of<IStreamClass>().AsOption(), Mock.Of<IStreamDefinition>().AsOption()) : (Option<IStreamClass>.None, Option<IStreamDefinition>.None));
+                definitionExists ? Mock.Of<IStreamDefinition>().AsOption() : Option<IStreamDefinition>.None);
         var service = this.CreateService();
 
         // Act
@@ -111,8 +111,7 @@ public class StreamingJobMaintenanceServiceTests : IClassFixture<LoggerFixture>
 
     [Theory]
     [MemberData(nameof(GenerateDeletedJobTestCases))]
-    public async Task HandleDeletedJob(V1Job job, IStreamClass streamClass, IStreamDefinition streamDefinition, bool expectToRestart,
-        bool expectBackfill)
+    public async Task HandleDeletedJob(V1Job job, IStreamDefinition streamDefinition, bool expectToRestart, bool expectBackfill)
     {
         // Arrange
         var mockSource = Source.From(new List<(WatchEventType, V1Job)>
@@ -128,7 +127,7 @@ public class StreamingJobMaintenanceServiceTests : IClassFixture<LoggerFixture>
         this.streamDefinitionRepositoryMock
                     .Setup(service =>
                         service.GetStreamDefinition(job.Namespace(), job.GetStreamKind(), job.GetStreamId()))
-                    .ReturnsAsync((streamClass.AsOption(), streamDefinition.AsOption()));
+                    .ReturnsAsync(streamDefinition.AsOption());
 
 
         var service = this.CreateService();
@@ -144,13 +143,13 @@ public class StreamingJobMaintenanceServiceTests : IClassFixture<LoggerFixture>
 
     public static IEnumerable<object[]> GenerateDeletedJobTestCases()
     {
-        yield return new object[] { CompletedJob, StreamClass, StreamDefinition, true, false };
-        yield return new object[] { ReloadRequestedJob, StreamClass, StreamDefinition, true, true };
-        yield return new object[] { SchemaMismatchJob, StreamClass, StreamDefinition, true, true };
+        yield return new object[] { CompletedJob, StreamDefinition, true, false };
+        yield return new object[] { ReloadRequestedJob, StreamDefinition, true, true };
+        yield return new object[] { SchemaMismatchJob, StreamDefinition, true, true };
 
-        yield return new object[] { CompletedJob, StreamClass, SuspendedStreamDefinition, false, false };
-        yield return new object[] { ReloadRequestedJob, StreamClass, SuspendedStreamDefinition, false, true };
-        yield return new object[] { SchemaMismatchJob, StreamClass, SuspendedStreamDefinition, false, true };
+        yield return new object[] { CompletedJob, SuspendedStreamDefinition, false, false };
+        yield return new object[] { ReloadRequestedJob, SuspendedStreamDefinition, false, true };
+        yield return new object[] { SchemaMismatchJob, SuspendedStreamDefinition, false, true };
     }
 
     public static IEnumerable<object[]> GenerateCompletedJobTestCases()


### PR DESCRIPTION
Part of #47

## Scope

Implemented:
- Reduce tech debt: make IStreamDefinitionRepository return only IStreamDefinition objects

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.