### PR TITLE
Remove streaming job operator service (part 1)

### DIFF
--- a/src/Services/Base/IStreamingJobCommandHandler.cs
+++ b/src/Services/Base/IStreamingJobCommandHandler.cs
@@ -1,14 +1,12 @@
-﻿using Arcane.Operator.Services.Base;
-using Arcane.Operator.Services.Commands;
+﻿using Arcane.Operator.Services.Commands;
 using k8s.Models;
 
-namespace Arcane.Operator.Services.CommandHandlers;
+namespace Arcane.Operator.Services.Base;
 
 /// <summary>
 /// Command handler for streaming job commands
 /// </summary>
 public interface IStreamingJobCommandHandler : ICommandHandler<StreamingJobCommand>,
-    ICommandHandler<RequestJobReloadCommand>,
     ICommandHandler<SetAnnotationCommand<V1Job>>
 {
 

--- a/src/Services/Base/IStreamingJobOperatorService.cs
+++ b/src/Services/Base/IStreamingJobOperatorService.cs
@@ -32,13 +32,6 @@ public interface IStreamingJobOperatorService
     Task<Option<V1Job>> GetStreamingJob(string streamId);
 
     /// <summary>
-    /// Marks streaming job for restart
-    /// </summary>
-    /// <param name="streamId">Stream identifier that should be terminated.</param>
-    /// <returns></returns>
-    Task<Option<StreamOperatorResponse>> RequestStreamingJobRestart(string streamId);
-
-    /// <summary>
     /// Marks streaming job for stop
     /// </summary>
     /// <param name="streamId">Stream identifier that should be terminated.</param>

--- a/src/Services/Base/IStreamingJobOperatorService.cs
+++ b/src/Services/Base/IStreamingJobOperatorService.cs
@@ -32,13 +32,6 @@ public interface IStreamingJobOperatorService
     Task<Option<V1Job>> GetStreamingJob(string streamId);
 
     /// <summary>
-    /// Marks streaming job for stop
-    /// </summary>
-    /// <param name="streamId">Stream identifier that should be terminated.</param>
-    /// <returns></returns>
-    Task<Option<StreamOperatorResponse>> RequestStreamingJobReload(string streamId);
-
-    /// <summary>
     /// Delete the streaming job
     /// </summary>
     /// <param name="kind">Stream definition kind</param>

--- a/src/Services/Base/IStreamingJobOperatorService.cs
+++ b/src/Services/Base/IStreamingJobOperatorService.cs
@@ -1,8 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Akka.Util;
-using Arcane.Operator.Models;
-using Arcane.Operator.Models.StreamClass.Base;
-using Arcane.Operator.Models.StreamDefinitions.Base;
 using k8s.Models;
 
 namespace Arcane.Operator.Services.Base;
@@ -13,16 +10,6 @@ public interface IStreamingJobOperatorService
     /// Namespace for kubernetes jobs
     /// </summary>
     public string StreamJobNamespace { get; }
-
-    /// <summary>
-    /// Starts a new stream using an existing stream definition in Kubernetes database.
-    /// </summary>
-    /// <param name="streamDefinition">Stream definition</param>
-    /// <param name="isBackfilling">Whether to perform a full reload for this stream.</param>
-    /// <param name="streamClass"></param>
-    /// <returns>StreamInfo if stream was created or None if an error occured</returns>
-    Task<Option<StreamOperatorResponse>> StartRegisteredStream(IStreamDefinition streamDefinition, bool isBackfilling,
-        IStreamClass streamClass);
 
     /// <summary>
     /// Retrieves a streaming job with name equal to streamId from the cluster. If not found, returns None.

--- a/src/Services/Base/IStreamingJobOperatorService.cs
+++ b/src/Services/Base/IStreamingJobOperatorService.cs
@@ -30,12 +30,4 @@ public interface IStreamingJobOperatorService
     /// <param name="streamId">Stream identifier that should be started.</param>
     /// <returns></returns>
     Task<Option<V1Job>> GetStreamingJob(string streamId);
-
-    /// <summary>
-    /// Delete the streaming job
-    /// </summary>
-    /// <param name="kind">Stream definition kind</param>
-    /// <param name="streamId">Stream identifier that should be terminated.</param>
-    /// <returns></returns>
-    Task<Option<StreamOperatorResponse>> DeleteJob(string kind, string streamId);
 }

--- a/src/Services/CommandHandlers/IStreamingJobCommandHandler.cs
+++ b/src/Services/CommandHandlers/IStreamingJobCommandHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Arcane.Operator.Services.Base;
 using Arcane.Operator.Services.Commands;
+using k8s.Models;
 
 namespace Arcane.Operator.Services.CommandHandlers;
 
@@ -7,8 +8,8 @@ namespace Arcane.Operator.Services.CommandHandlers;
 /// Command handler for streaming job commands
 /// </summary>
 public interface IStreamingJobCommandHandler : ICommandHandler<StreamingJobCommand>,
-    ICommandHandler<RequestJobRestartCommand>,
-    ICommandHandler<RequestJobReloadCommand>
+    ICommandHandler<RequestJobReloadCommand>,
+    ICommandHandler<SetAnnotationCommand<V1Job>>
 {
 
 }

--- a/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
+++ b/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
@@ -45,11 +45,6 @@ public class StreamingJobCommandHandler : IStreamingJobCommandHandler
         _ => throw new ArgumentOutOfRangeException(nameof(command), command, null)
     };
 
-    public Task Handle(RequestJobReloadCommand command)
-    {
-        return this.streamingJobOperatorService.RequestStreamingJobReload(command.affectedResource.GetStreamId());
-    }
-
     public Task Handle(SetAnnotationCommand<V1Job> command)
     {
         return this.kubeCluster.AnnotateJob(command.affectedResource.Name(), command.affectedResource.Namespace(),

--- a/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
+++ b/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
@@ -41,7 +41,7 @@ public class StreamingJobCommandHandler : IStreamingJobCommandHandler
                 { HasValue: true, Value: var sc } => this.streamingJobOperatorService.StartRegisteredStream(startJob.streamDefinition, startJob.IsBackfilling, sc),
                 { HasValue: false } => throw new InvalidOperationException($"Stream class not found for {startJob.streamDefinition.Kind}"),
             }),
-        StopJob stopJob => this.streamingJobOperatorService.DeleteJob(stopJob.streamKind, stopJob.streamId),
+        StopJob stopJob => this.kubeCluster.DeleteJob(stopJob.name, stopJob.nameSpace),
         _ => throw new ArgumentOutOfRangeException(nameof(command), command, null)
     };
 

--- a/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
+++ b/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
@@ -52,7 +52,7 @@ public class StreamingJobCommandHandler : IStreamingJobCommandHandler
             .TryMap(job => job.AsOption(),
                 exception =>
                 {
-                    this.logger.LogError(exception, "Failed to annotate {streamId} with {annotationKey}:{annotationValue}", 
+                    this.logger.LogError(exception, "Failed to annotate {streamId} with {annotationKey}:{annotationValue}",
                         command.affectedResource, command.annotationKey, command.annotationValue);
                     return Option<V1Job>.None;
                 });

--- a/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
+++ b/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Akka.Util;
+using Akka.Util.Extensions;
 using Arcane.Operator.Extensions;
 using Arcane.Operator.Services.Base;
 using Arcane.Operator.Services.Commands;
 using k8s.Models;
+using Microsoft.Extensions.Logging;
+using Snd.Sdk.Kubernetes.Base;
 using Snd.Sdk.Tasks;
 
 namespace Arcane.Operator.Services.CommandHandlers;
@@ -13,13 +17,18 @@ public class StreamingJobCommandHandler : IStreamingJobCommandHandler
 {
     private readonly IStreamClassRepository streamClassRepository;
     private readonly IStreamingJobOperatorService streamingJobOperatorService;
+    private readonly IKubeCluster kubeCluster;
+    private readonly ILogger<StreamingJobCommandHandler> logger;
 
     public StreamingJobCommandHandler(
         IStreamClassRepository streamClassRepository,
-        IStreamingJobOperatorService streamingJobOperatorService)
+        IStreamingJobOperatorService streamingJobOperatorService,
+        IKubeCluster kubeCluster, ILogger<StreamingJobCommandHandler> logger)
     {
         this.streamClassRepository = streamClassRepository;
         this.streamingJobOperatorService = streamingJobOperatorService;
+        this.kubeCluster = kubeCluster;
+        this.logger = logger;
     }
 
     /// <inheritdoc cref="ICommandHandler{T}.Handle" />
@@ -36,13 +45,21 @@ public class StreamingJobCommandHandler : IStreamingJobCommandHandler
         _ => throw new ArgumentOutOfRangeException(nameof(command), command, null)
     };
 
-    public Task Handle(RequestJobRestartCommand command)
-    {
-        return this.streamingJobOperatorService.RequestStreamingJobRestart(command.affectedResource.GetStreamId());
-    }
-
     public Task Handle(RequestJobReloadCommand command)
     {
         return this.streamingJobOperatorService.RequestStreamingJobReload(command.affectedResource.GetStreamId());
+    }
+
+    public Task Handle(SetAnnotationCommand<V1Job> command)
+    {
+        return this.kubeCluster.AnnotateJob(command.affectedResource.Name(), command.affectedResource.Namespace(),
+                command.annotationKey, command.annotationValue)
+            .TryMap(job => job.AsOption(),
+                exception =>
+                {
+                    this.logger.LogError(exception, "Failed to annotate {streamId} with {annotationKey}:{annotationValue}", 
+                        command.affectedResource, command.annotationKey, command.annotationValue);
+                    return Option<V1Job>.None;
+                });
     }
 }

--- a/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
+++ b/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
@@ -1,12 +1,17 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Util;
 using Akka.Util.Extensions;
 using Arcane.Operator.Extensions;
+using Arcane.Operator.Models;
+using Arcane.Operator.Models.StreamClass.Base;
+using Arcane.Operator.Models.StreamDefinitions.Base;
 using Arcane.Operator.Services.Base;
 using Arcane.Operator.Services.Commands;
 using k8s.Models;
 using Microsoft.Extensions.Logging;
+using Snd.Sdk.Kubernetes;
 using Snd.Sdk.Kubernetes.Base;
 using Snd.Sdk.Tasks;
 
@@ -19,16 +24,20 @@ public class StreamingJobCommandHandler : IStreamingJobCommandHandler
     private readonly IStreamingJobOperatorService streamingJobOperatorService;
     private readonly IKubeCluster kubeCluster;
     private readonly ILogger<StreamingJobCommandHandler> logger;
+    private readonly IStreamingJobTemplateRepository streamingJobTemplateRepository;
 
     public StreamingJobCommandHandler(
         IStreamClassRepository streamClassRepository,
         IStreamingJobOperatorService streamingJobOperatorService,
-        IKubeCluster kubeCluster, ILogger<StreamingJobCommandHandler> logger)
+        IKubeCluster kubeCluster,
+        ILogger<StreamingJobCommandHandler> logger,
+        IStreamingJobTemplateRepository streamingJobTemplateRepository)
     {
         this.streamClassRepository = streamClassRepository;
         this.streamingJobOperatorService = streamingJobOperatorService;
         this.kubeCluster = kubeCluster;
         this.logger = logger;
+        this.streamingJobTemplateRepository = streamingJobTemplateRepository;
     }
 
     /// <inheritdoc cref="ICommandHandler{T}.Handle" />
@@ -38,7 +47,7 @@ public class StreamingJobCommandHandler : IStreamingJobCommandHandler
             .Get(startJob.streamDefinition.Namespace(), startJob.streamDefinition.Kind)
             .Map(maybeSc => maybeSc switch
             {
-                { HasValue: true, Value: var sc } => this.streamingJobOperatorService.StartRegisteredStream(startJob.streamDefinition, startJob.IsBackfilling, sc),
+                { HasValue: true, Value: var sc } => this.StartJob(startJob.streamDefinition, startJob.IsBackfilling, sc),
                 { HasValue: false } => throw new InvalidOperationException($"Stream class not found for {startJob.streamDefinition.Kind}"),
             }),
         StopJob stopJob => this.kubeCluster.DeleteJob(stopJob.name, stopJob.nameSpace),
@@ -56,5 +65,52 @@ public class StreamingJobCommandHandler : IStreamingJobCommandHandler
                         command.affectedResource, command.annotationKey, command.annotationValue);
                     return Option<V1Job>.None;
                 });
+    }
+
+    private Task StartJob(IStreamDefinition streamDefinition, bool isBackfilling, IStreamClass streamClass)
+    {
+        var template = streamDefinition.GetJobTemplate(isBackfilling);
+        return this.streamingJobTemplateRepository
+            .GetStreamingJobTemplate(template.Kind, streamDefinition.Namespace(), template.Name)
+            .Map(jobTemplate =>
+            {
+                if (!jobTemplate.HasValue)
+                {
+                    return Task.FromResult(StreamOperatorResponse.OperationFailed(streamDefinition.Metadata.Namespace(),
+                            streamDefinition.Kind,
+                            streamDefinition.StreamId,
+                            $"Failed to find job template with kind {template.Kind} and name {template.Name}")
+                        .AsOption());
+                }
+
+                var job = jobTemplate
+                    .Value
+                    .GetJob()
+                    .WithStreamingJobLabels(streamDefinition.StreamId, isBackfilling, streamDefinition.Kind)
+                    .WithStreamingJobAnnotations(streamDefinition.GetConfigurationChecksum())
+                    .WithMetadataAnnotations(streamClass)
+                    .WithCustomEnvironment(streamDefinition.ToV1EnvFromSources(streamClass))
+                    .WithCustomEnvironment(streamDefinition.ToEnvironment(isBackfilling, streamClass))
+                    .WithOwnerReference(streamDefinition)
+                    .WithName(streamDefinition.StreamId);
+                this.logger.LogInformation("Starting a new stream job with an id {streamId}",
+                    streamDefinition.StreamId);
+                return this.kubeCluster
+                    .SendJob(job, streamDefinition.Metadata.Namespace(), CancellationToken.None)
+                    .TryMap(
+                        _ => isBackfilling
+                            ? StreamOperatorResponse.Reloading(streamDefinition.Metadata.Namespace(),
+                                streamDefinition.Kind,
+                                streamDefinition.StreamId)
+                            : StreamOperatorResponse.Running(streamDefinition.Metadata.Namespace(),
+                                streamDefinition.Kind,
+                                streamDefinition.StreamId),
+                        exception =>
+                        {
+                            this.logger.LogError(exception, "Failed to send job");
+                            return Option<StreamOperatorResponse>.None;
+                        });
+            })
+            .Flatten();
     }
 }

--- a/src/Services/Commands/StreamingJobCommands.cs
+++ b/src/Services/Commands/StreamingJobCommands.cs
@@ -20,9 +20,9 @@ public record StartJob(IStreamDefinition streamDefinition, bool IsBackfilling) :
 /// <summary>
 /// Stop a streaming job
 /// </summary>
-/// <param name="streamKind">Stream kind</param>
-/// <param name="streamId">Id of the stream</param>
-public record StopJob(string streamKind, string streamId) : StreamingJobCommand;
+/// <param name="name">Job name to stop</param>
+/// <param name="nameSpace">Job namespace to stop</param>
+public record StopJob(string name, string nameSpace) : StreamingJobCommand;
 
 /// <summary>
 /// Request a streaming job to restart

--- a/src/Services/Operator/StreamOperatorService.cs
+++ b/src/Services/Operator/StreamOperatorService.cs
@@ -11,7 +11,6 @@ using Arcane.Operator.Extensions;
 using Arcane.Operator.Models.StreamClass.Base;
 using Arcane.Operator.Models.StreamDefinitions.Base;
 using Arcane.Operator.Services.Base;
-using Arcane.Operator.Services.CommandHandlers;
 using Arcane.Operator.Services.Commands;
 using Arcane.Operator.Services.Models;
 using k8s;
@@ -139,8 +138,7 @@ public class StreamOperatorService : IStreamOperatorService, IDisposable
         {
             { HasValue: true, Value: var job } when job.IsReloading() => new Reloading(streamDefinition),
             { HasValue: true, Value: var job } when !job.IsReloading() => new Running(streamDefinition),
-            { HasValue: true, Value: var job } when streamDefinition.Suspended => new StopJob(job.GetStreamId(),
-                job.GetStreamKind()),
+            { HasValue: true, Value: var job } when streamDefinition.Suspended => new StopJob(job.Name(), job.Namespace()),
             { HasValue: false } when streamDefinition.Suspended => new Suspended(streamDefinition),
             { HasValue: false } when !streamDefinition.Suspended => new StartJob(streamDefinition, true),
             _ => throw new ArgumentOutOfRangeException(nameof(maybeJob), maybeJob, null)
@@ -163,10 +161,10 @@ public class StreamOperatorService : IStreamOperatorService, IDisposable
             },
             { HasValue: false } => new StartJob(streamDefinition, false).AsList(),
 
-            { HasValue: true, Value: var job } when streamDefinition.CrashLoopDetected => new StopJob(job.GetStreamId(),
-                job.GetStreamKind()).AsList(),
-            { HasValue: true, Value: var job } when streamDefinition.Suspended => new StopJob(job.GetStreamId(),
-                job.GetStreamKind()).AsList(),
+            { HasValue: true, Value: var job } when streamDefinition.CrashLoopDetected => new StopJob(job.Name(),
+                job.Namespace()).AsList(),
+            { HasValue: true, Value: var job } when streamDefinition.Suspended => new StopJob(job.Name(),
+                job.Namespace()).AsList(),
             { HasValue: true, Value: var job } when !job.ConfigurationMatches(streamDefinition) => new
                 List<KubernetesCommand>
                 {

--- a/src/Services/Streams/StreamingJobOperatorService.cs
+++ b/src/Services/Streams/StreamingJobOperatorService.cs
@@ -1,17 +1,11 @@
-using System.Threading;
 using System.Threading.Tasks;
 using Akka.Util;
 using Akka.Util.Extensions;
 using Arcane.Operator.Configurations;
-using Arcane.Operator.Extensions;
-using Arcane.Operator.Models;
-using Arcane.Operator.Models.StreamClass.Base;
-using Arcane.Operator.Models.StreamDefinitions.Base;
 using Arcane.Operator.Services.Base;
 using k8s.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Snd.Sdk.Kubernetes;
 using Snd.Sdk.Kubernetes.Base;
 using Snd.Sdk.Tasks;
 
@@ -22,18 +16,15 @@ public class StreamingJobOperatorService : IStreamingJobOperatorService
     private readonly StreamingJobOperatorServiceConfiguration configuration;
     private readonly IKubeCluster kubernetesService;
     private readonly ILogger<StreamingJobOperatorService> logger;
-    private readonly IStreamingJobTemplateRepository streamingJobTemplateRepository;
 
     public StreamingJobOperatorService(
         ILogger<StreamingJobOperatorService> logger,
         IOptions<StreamingJobOperatorServiceConfiguration> configuration,
-        IKubeCluster kubernetesService,
-        IStreamingJobTemplateRepository streamingJobTemplateRepository)
+        IKubeCluster kubernetesService)
     {
         this.logger = logger;
         this.configuration = configuration.Value;
         this.kubernetesService = kubernetesService;
-        this.streamingJobTemplateRepository = streamingJobTemplateRepository;
     }
 
 
@@ -49,57 +40,4 @@ public class StreamingJobOperatorService : IStreamingJobOperatorService
             });
     }
 
-    public Task<Option<StreamOperatorResponse>> StartRegisteredStream(IStreamDefinition streamDefinition, bool isBackfilling,
-        IStreamClass streamClass)
-    {
-        var template = streamDefinition.GetJobTemplate(isBackfilling);
-        return this.streamingJobTemplateRepository
-            .GetStreamingJobTemplate(template.Kind, streamDefinition.Namespace(), template.Name)
-            .Map(jobTemplate =>
-            {
-                if (!jobTemplate.HasValue)
-                {
-                    return Task.FromResult(StreamOperatorResponse.OperationFailed(streamDefinition.Metadata.Namespace(),
-                            streamDefinition.Kind,
-                            streamDefinition.StreamId,
-                            $"Failed to find job template with kind {template.Kind} and name {template.Name}")
-                        .AsOption());
-                }
-
-                var job = jobTemplate
-                    .Value
-                    .GetJob()
-                    .WithStreamingJobLabels(streamDefinition.StreamId, isBackfilling, streamDefinition.Kind)
-                    .WithStreamingJobAnnotations(streamDefinition.GetConfigurationChecksum())
-                    .WithMetadataAnnotations(streamClass)
-                    .WithCustomEnvironment(streamDefinition.ToV1EnvFromSources(streamClass))
-                    .WithCustomEnvironment(streamDefinition.ToEnvironment(isBackfilling, streamClass))
-                    .WithOwnerReference(streamDefinition)
-                    .WithName(streamDefinition.StreamId);
-                this.logger.LogInformation("Starting a new stream job with an id {streamId}",
-                    streamDefinition.StreamId);
-                return this.kubernetesService
-                    .SendJob(job, streamDefinition.Metadata.Namespace(), CancellationToken.None)
-                    .TryMap(
-                        _ => isBackfilling
-                            ? StreamOperatorResponse.Reloading(streamDefinition.Metadata.Namespace(),
-                                streamDefinition.Kind,
-                                streamDefinition.StreamId)
-                            : StreamOperatorResponse.Running(streamDefinition.Metadata.Namespace(),
-                                streamDefinition.Kind,
-                                streamDefinition.StreamId),
-                        exception =>
-                        {
-                            this.logger.LogError(exception, "Failed to send job");
-                            return Option<StreamOperatorResponse>.None;
-                        });
-            })
-            .Flatten();
-    }
-
-    public Task<Option<StreamOperatorResponse>> DeleteJob(string kind, string streamId)
-    {
-        return this.kubernetesService.DeleteJob(streamId, this.StreamJobNamespace)
-            .Map(_ => StreamOperatorResponse.Suspended(this.StreamJobNamespace, kind, streamId).AsOption());
-    }
 }

--- a/test/Extensions/V1JobExtensions.cs
+++ b/test/Extensions/V1JobExtensions.cs
@@ -1,0 +1,10 @@
+﻿using System.Linq;
+using k8s.Models;
+
+namespace Arcane.Operator.Tests.Extensions;
+
+public static class V1JobExtensions
+{
+    public static bool IsBackfilling(this V1Job job) =>
+        job.Spec.Template.Spec.Containers[0].Env.Any(i => i.Name == "STREAMCONTEXT__BACKFILL" && i.Value == "true");
+}

--- a/test/Services/StreamClassOperatorServiceTests.cs
+++ b/test/Services/StreamClassOperatorServiceTests.cs
@@ -173,6 +173,7 @@ public class StreamClassOperatorServiceTests : IClassFixture<LoggerFixture>, ICl
             .AddSingleton(this.loggerFixture.Factory.CreateLogger<StreamingJobOperatorService>())
             .AddSingleton(this.loggerFixture.Factory.CreateLogger<AnnotationCommandHandler>())
             .AddSingleton(this.loggerFixture.Factory.CreateLogger<UpdateStatusCommandHandler>())
+            .AddSingleton(this.loggerFixture.Factory.CreateLogger<StreamingJobCommandHandler>())
             .AddSingleton(loggerFixture.Factory)
             .AddSingleton(optionsMock.Object)
             .AddSingleton(metricsReporterConfiguration)

--- a/test/Services/StreamClassOperatorServiceTests.cs
+++ b/test/Services/StreamClassOperatorServiceTests.cs
@@ -9,8 +9,6 @@ using Akka.Util.Extensions;
 using Arcane.Operator.Configurations;
 using Arcane.Operator.Configurations.Common;
 using Arcane.Operator.Models.StreamClass;
-using Arcane.Operator.Models.StreamClass.Base;
-using Arcane.Operator.Models.StreamDefinitions;
 using Arcane.Operator.Models.StreamDefinitions.Base;
 using Arcane.Operator.Services.Base;
 using Arcane.Operator.Services.CommandHandlers;
@@ -33,6 +31,7 @@ using Snd.Sdk.Kubernetes.Base;
 using Snd.Sdk.Metrics.Base;
 using Xunit;
 using static Arcane.Operator.Tests.Services.TestCases.StreamClassTestCases;
+using static Arcane.Operator.Tests.Services.TestCases.StreamingJobTemplateTestCases;
 
 namespace Arcane.Operator.Tests.Services;
 
@@ -48,11 +47,15 @@ public class StreamClassOperatorServiceTests : IClassFixture<LoggerFixture>, ICl
     private readonly Mock<IStreamingJobOperatorService> streamingJobOperatorServiceMock = new();
     private readonly Mock<IReactiveResourceCollection<IStreamDefinition>> streamDefinitionSourceMock = new();
     private readonly Mock<IStreamClassRepository> streamClassRepositoryMock = new();
+    private readonly Mock<IStreamingJobTemplateRepository> streamingJobTemplateRepositoryMock = new();
 
     public StreamClassOperatorServiceTests(LoggerFixture loggerFixture)
     {
         this.loggerFixture = loggerFixture;
         this.materializer = this.actorSystem.Materializer();
+        this.streamingJobTemplateRepositoryMock
+            .Setup(s => s.GetStreamingJobTemplate(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(StreamingJobTemplate.AsOption());
     }
 
     [Fact]
@@ -93,7 +96,8 @@ public class StreamClassOperatorServiceTests : IClassFixture<LoggerFixture>, ICl
         await Task.Delay(5000);
 
         // Assert
-        this.streamingJobOperatorServiceMock.Verify(service => service.StartRegisteredStream(It.IsAny<StreamDefinition>(), It.IsAny<bool>(), It.IsAny<IStreamClass>()));
+        this.kubeClusterMock.Verify(
+            service => service.SendJob(It.IsAny<V1Job>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
     }
 
     [Fact]
@@ -130,8 +134,8 @@ public class StreamClassOperatorServiceTests : IClassFixture<LoggerFixture>, ICl
         await Task.Delay(5000);
 
         // Assert
-        this.streamingJobOperatorServiceMock.Verify(
-                service => service.StartRegisteredStream(It.IsAny<StreamDefinition>(), It.IsAny<bool>(), It.IsAny<IStreamClass>()),
+        this.kubeClusterMock.Verify(
+                service => service.SendJob(It.IsAny<V1Job>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
                 Times.Never
             );
     }
@@ -156,6 +160,7 @@ public class StreamClassOperatorServiceTests : IClassFixture<LoggerFixture>, ICl
             .AddSingleton(this.kubeClusterMock.Object)
             .AddSingleton(this.streamingJobOperatorServiceMock.Object)
             .AddSingleton(this.streamDefinitionSourceMock.Object)
+            .AddSingleton(this.streamingJobTemplateRepositoryMock.Object)
             .AddSingleton<IStreamClassRepository, StreamClassRepository>()
             .AddMemoryCache()
             .AddSingleton<IStreamOperatorService, StreamOperatorService>()

--- a/test/Services/StreamOperatorServiceTests.cs
+++ b/test/Services/StreamOperatorServiceTests.cs
@@ -106,8 +106,12 @@ public class StreamOperatorServiceTests : IClassFixture<LoggerFixture>, IDisposa
             It.IsAny<string>()))
             .Callback(() => this.tcs.SetResult());
 
-        streamingJobOperatorServiceMock
-            .Setup(service => service.DeleteJob(It.IsAny<string>(), It.IsAny<string>()))
+       this.kubeClusterMock 
+            .Setup(service => service.DeleteJob(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<PropagationPolicy>()))
             .Callback(() => this.tcs.SetResult());
 
         // Act
@@ -134,8 +138,12 @@ public class StreamOperatorServiceTests : IClassFixture<LoggerFixture>, IDisposa
                     It.IsAny<StreamDefinition>(), false, It.IsAny<IStreamClass>()),
             Times.Exactly(expectRestart && !streamingJobExists ? 1 : 0));
 
-        streamingJobOperatorServiceMock.Verify(service
-                => service.DeleteJob(It.IsAny<string>(), It.IsAny<string>()),
+        this.kubeClusterMock.Verify(service
+                => service.DeleteJob(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<PropagationPolicy>()),
             Times.Exactly(expectTermination ? 1 : 0));
     }
 

--- a/test/Services/StreamOperatorServiceTests.cs
+++ b/test/Services/StreamOperatorServiceTests.cs
@@ -106,13 +106,13 @@ public class StreamOperatorServiceTests : IClassFixture<LoggerFixture>, IDisposa
             It.IsAny<string>()))
             .Callback(() => this.tcs.SetResult());
 
-       this.kubeClusterMock 
-            .Setup(service => service.DeleteJob(
-                It.IsAny<string>(),
-                It.IsAny<string>(),
-                It.IsAny<CancellationToken>(),
-                It.IsAny<PropagationPolicy>()))
-            .Callback(() => this.tcs.SetResult());
+        this.kubeClusterMock
+             .Setup(service => service.DeleteJob(
+                 It.IsAny<string>(),
+                 It.IsAny<string>(),
+                 It.IsAny<CancellationToken>(),
+                 It.IsAny<PropagationPolicy>()))
+             .Callback(() => this.tcs.SetResult());
 
         // Act
         var sp = this.CreateServiceProvider();
@@ -125,7 +125,7 @@ public class StreamOperatorServiceTests : IClassFixture<LoggerFixture>, IDisposa
                 => service.StartRegisteredStream(
                     It.IsAny<StreamDefinition>(), true, It.IsAny<IStreamClass>()),
             Times.Exactly(expectBackfill ? 1 : 0));
-        
+
         this.kubeClusterMock
             .Verify(c => c.AnnotateJob(It.IsAny<string>(),
             It.IsAny<string>(),

--- a/test/Services/StreamOperatorServiceTests.cs
+++ b/test/Services/StreamOperatorServiceTests.cs
@@ -197,7 +197,7 @@ public class StreamOperatorServiceTests : IClassFixture<LoggerFixture>, IDisposa
 
     public static IEnumerable<object[]> GenerateReloadTestCases()
     {
-        // yield return new object[] { ReloadRequestedStreamDefinition, true, true };
+        yield return new object[] { ReloadRequestedStreamDefinition, true, true };
         yield return new object[] { ReloadRequestedStreamDefinition, false, false };
     }
 

--- a/test/Services/StreamingJobMaintenanceServiceTests.cs
+++ b/test/Services/StreamingJobMaintenanceServiceTests.cs
@@ -9,7 +9,6 @@ using Akka.Util;
 using Akka.Util.Extensions;
 using Arcane.Operator.Configurations;
 using Arcane.Operator.Extensions;
-using Arcane.Operator.Models.StreamClass.Base;
 using Arcane.Operator.Models.StreamDefinitions.Base;
 using Arcane.Operator.Services.Base;
 using Arcane.Operator.Services.CommandHandlers;
@@ -17,6 +16,7 @@ using Arcane.Operator.Services.Commands;
 using Arcane.Operator.Services.Maintenance;
 using Arcane.Operator.Services.Metrics;
 using Arcane.Operator.Services.Streams;
+using Arcane.Operator.Tests.Extensions;
 using Arcane.Operator.Tests.Fixtures;
 using k8s;
 using k8s.Models;
@@ -30,6 +30,7 @@ using Xunit;
 using static Arcane.Operator.Tests.Services.TestCases.JobTestCases;
 using static Arcane.Operator.Tests.Services.TestCases.StreamDefinitionTestCases;
 using static Arcane.Operator.Tests.Services.TestCases.StreamClassTestCases;
+using static Arcane.Operator.Tests.Services.TestCases.StreamingJobTemplateTestCases;
 
 namespace Arcane.Operator.Tests.Services;
 
@@ -45,6 +46,7 @@ public class StreamingJobMaintenanceServiceTests : IClassFixture<LoggerFixture>
     private readonly Mock<IStreamingJobOperatorService> streamingJobOperatorServiceMock = new();
     private readonly Mock<IResourceCollection<IStreamDefinition>> streamDefinitionRepositoryMock = new();
     private readonly Mock<IStreamClassRepository> streamClassRepositoryMock = new();
+    private readonly Mock<IStreamingJobTemplateRepository> streamingJobTemplateRepositoryMock = new();
 
     public StreamingJobMaintenanceServiceTests(LoggerFixture loggerFixture)
     {
@@ -54,6 +56,10 @@ public class StreamingJobMaintenanceServiceTests : IClassFixture<LoggerFixture>
         this.streamClassRepositoryMock
             .Setup(m => m.Get(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(StreamClass.AsOption());
+
+        this.streamingJobTemplateRepositoryMock
+            .Setup(s => s.GetStreamingJobTemplate(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(StreamingJobTemplate.AsOption());
     }
 
     [Theory]
@@ -72,15 +78,17 @@ public class StreamingJobMaintenanceServiceTests : IClassFixture<LoggerFixture>
 
         this.streamDefinitionRepositoryMock
             .Setup(service => service.Get(job.Name(), job.ToOwnerApiRequest()))
-            .ReturnsAsync(() => definitionExists ? Mock.Of<IStreamDefinition>().AsOption() : Option<IStreamDefinition>.None);
+            .ReturnsAsync(() => definitionExists ? StreamDefinition.AsOption() : Option<IStreamDefinition>.None);
         var service = this.CreateService();
 
         // Act
         await service.GetJobEventsGraph(CancellationToken.None).Run(this.materializer);
 
         // Assert
-        this.streamingJobOperatorServiceMock
-            .Verify(s => s.StartRegisteredStream(It.IsAny<IStreamDefinition>(), isBackfilling, It.IsAny<IStreamClass>()), Times.Exactly(definitionExists && expectRestart ? 1 : 0));
+        this.kubeClusterMock.Verify(s =>
+            s.SendJob(It.Is<V1Job>(j => isBackfilling ? j.IsBackfilling() : !j.IsBackfilling()), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(definitionExists && expectRestart ? 1 : 0)
+        );
     }
 
     [Theory]
@@ -137,8 +145,8 @@ public class StreamingJobMaintenanceServiceTests : IClassFixture<LoggerFixture>
         // Act
         await service.GetJobEventsGraph(CancellationToken.None).Run(this.materializer);
 
-        this.streamingJobOperatorServiceMock.Verify(s =>
-                s.StartRegisteredStream(streamDefinition, expectBackfill, It.IsAny<IStreamClass>()),
+        this.kubeClusterMock.Verify(s =>
+            s.SendJob(It.Is<V1Job>(j => expectBackfill ? j.IsBackfilling() : !j.IsBackfilling()), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Exactly(expectToRestart ? 1 : 0)
         );
     }
@@ -197,6 +205,7 @@ public class StreamingJobMaintenanceServiceTests : IClassFixture<LoggerFixture>
             .AddSingleton(this.kubeClusterMock.Object)
             .AddSingleton(this.streamDefinitionRepositoryMock.Object)
             .AddSingleton(this.streamClassRepositoryMock.Object)
+            .AddSingleton(this.streamingJobTemplateRepositoryMock.Object)
             .AddSingleton<ICommandHandler<UpdateStatusCommand>, UpdateStatusCommandHandler>()
             .AddSingleton<ICommandHandler<SetAnnotationCommand<IStreamDefinition>>, AnnotationCommandHandler>()
             .AddSingleton<IStreamingJobCommandHandler, StreamingJobCommandHandler>()

--- a/test/Services/StreamingJobMaintenanceServiceTests.cs
+++ b/test/Services/StreamingJobMaintenanceServiceTests.cs
@@ -201,6 +201,7 @@ public class StreamingJobMaintenanceServiceTests : IClassFixture<LoggerFixture>
             .AddSingleton(this.loggerFixture.Factory.CreateLogger<StreamingJobOperatorService>())
             .AddSingleton(this.loggerFixture.Factory.CreateLogger<AnnotationCommandHandler>())
             .AddSingleton(this.loggerFixture.Factory.CreateLogger<UpdateStatusCommandHandler>())
+            .AddSingleton(this.loggerFixture.Factory.CreateLogger<StreamingJobCommandHandler>())
             .AddSingleton<IMetricsReporter, MetricsReporter>()
             .AddSingleton(Mock.Of<MetricsService>())
             .AddSingleton<StreamingJobMaintenanceService>()

--- a/test/Services/StreamingJobMaintenanceServiceTests.cs
+++ b/test/Services/StreamingJobMaintenanceServiceTests.cs
@@ -102,8 +102,12 @@ public class StreamingJobMaintenanceServiceTests : IClassFixture<LoggerFixture>
         // Act
         await service.GetJobEventsGraph(CancellationToken.None).Run(this.materializer);
 
-        this.streamingJobOperatorServiceMock
-            .Verify(s => s.DeleteJob(It.IsAny<string>(), It.IsAny<string>()),
+        this.kubeClusterMock
+            .Verify(s => s.DeleteJob(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<PropagationPolicy>()),
                 Times.Exactly(expectToStopJob ? 1 : 0)
             );
     }

--- a/test/Services/TestCases/StreamingJobTemplateTestCases.cs
+++ b/test/Services/TestCases/StreamingJobTemplateTestCases.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Arcane.Operator.Models.JobTemplates.V1Beta1;
+using k8s.Models;
+
+namespace Arcane.Operator.Tests.Services.TestCases;
+
+public static class StreamingJobTemplateTestCases
+{
+
+    public static V1Beta1StreamingJobTemplate StreamingJobTemplate => new()
+    {
+        Spec = new V1Beta1StreamingJobTemplateSpec
+        {
+            Template = CreateJob(new V1PodSpec { Containers = new List<V1Container> { new() } })
+        }
+    };
+
+    private static V1Job CreateJob(V1PodSpec v1PodSpec) =>
+         new()
+         {
+             Metadata = new V1ObjectMeta
+             {
+                 Name = "template"
+             },
+             Spec = new V1JobSpec
+             {
+                 Template = new V1PodTemplateSpec
+                 {
+                     Metadata = new V1ObjectMeta(),
+                     Spec = v1PodSpec
+                 }
+             },
+         };
+}


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-operator/issues/47

This PR focused on moving code from old services to new command handlers.

## Scope

Implemented:
1. From the `StreamingJobOperatorService` removed the following methods:
 - `StartRegisteredStream`
 - `RequestStreamingJobRestart`
 - `RequestStreamingJobReload`
 - `DeleteJob`

2. Added the `SetAnnotationCommand<V1Job>` command handler to `StreamingJobCommandHandler` 
3. Method `StartRegisteredStream` was moved to `StreamingJobCommandHandler` and renamed to `StartStream`
4. Test classes updated accordingly.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.