### PR TITLE
Clear old operator versions

### DIFF
--- a/.github/workflows/cleanup-repository.yaml
+++ b/.github/workflows/cleanup-repository.yaml
@@ -1,7 +1,7 @@
 name: Remove old artifacts
 on:
-  schedule:
-    - cron: '0 12 * * *' # every day at 12:00 UTC
+#  schedule:
+#    - cron: '0 12 * * *' # every day at 12:00 UTC
   workflow_dispatch:
     
 jobs:

--- a/.github/workflows/cleanup-repository.yaml
+++ b/.github/workflows/cleanup-repository.yaml
@@ -1,0 +1,31 @@
+name: Remove old artifacts
+on:
+  schedule:
+    - cron: '0 12 * * *' # every day at 12:00 UTC
+  workflow_dispatch:
+    
+jobs:
+  remove_old_artifacts:
+    name: Remove old artifacts
+    runs-on: ubuntu-latest
+    
+    timeout-minutes: 10 # stop the task if it takes longer
+
+    steps:
+      - name: Delete old package versions of arcane-operator
+        uses: actions/delete-package-versions@v5.0.0
+        with:
+          package-name: 'arcane-operator'
+          package-type: container
+          token: ${{ secrets.GITHUB_PAT }}
+          min-versions-to-keep: 10
+          delete-only-pre-release-versions: "true"
+          
+      - name: Delete old package versions of helm/arcane-operator
+        uses: actions/delete-package-versions@v5.0.0
+        with:
+          package-name: 'helm/arcane-operator'
+          package-type: container
+          token: ${{ secrets.GITHUB_PAT }}
+          min-versions-to-keep: 10
+          delete-only-pre-release-versions: "true"


### PR DESCRIPTION
Resolves https://github.com/SneaksAndData/arcane-operator/issues/32

## Scope

Implemented:
- Added the workflow that can clear versions periodically

**NOTE:** the schedule is turned off until the action is tested manually.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.