### PR TITLE
Do not set the 'latest' tag to images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}},value=${{steps.version.outputs.version}}
+          flavor:
+            latest=false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0


### PR DESCRIPTION
## Scope

Implemented:
- Do not assign the `latest` tag to an image. It should fix the build fails caused by tag immutability in resent action runs.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.