### PR TITLE
Fix HTTP Conflict status code handling

### DIFF
--- a/src/Models/Resources/Status/V1Alpha1/V1Alpha1StreamStatus.cs
+++ b/src/Models/Resources/Status/V1Alpha1/V1Alpha1StreamStatus.cs
@@ -2,7 +2,7 @@
 
 namespace Arcane.Operator.Models.Resources.Status.V1Alpha1;
 
-public class V1Alpha1StreamStatus
+public record V1Alpha1StreamStatus
 {
     /// <summary>
     /// List of conditions of the stream

--- a/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
+++ b/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
@@ -108,7 +108,7 @@ public class StreamingJobCommandHandler : ICommandHandler<StreamingJobCommand>
 
     private UpdateStatusCommand HandleError(Exception exception, IStreamDefinition streamDefinition, bool isBackfilling)
     {
-        if (exception is HttpOperationException {Response.StatusCode: HttpStatusCode.Conflict })
+        if (exception is HttpOperationException { Response.StatusCode: HttpStatusCode.Conflict })
         {
             this.logger.LogWarning(exception, "Streaming job with ID {streamId} already exists", streamDefinition.StreamId);
             return isBackfilling ? new Reloading(streamDefinition) : new Running(streamDefinition);

--- a/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
+++ b/src/Services/CommandHandlers/StreamingJobCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka;
@@ -13,6 +14,7 @@ using Arcane.Operator.Services.Base;
 using Arcane.Operator.Services.Base.CommandHandlers;
 using Arcane.Operator.Services.Base.Repositories.CustomResources;
 using Google.Protobuf.WellKnownTypes;
+using k8s.Autorest;
 using k8s.Models;
 using Microsoft.Extensions.Logging;
 using Snd.Sdk.Kubernetes;
@@ -95,7 +97,7 @@ public class StreamingJobCommandHandler : ICommandHandler<StreamingJobCommand>
                 .SendJob(job, streamDefinition.Metadata.Namespace(), CancellationToken.None)
                 .TryMap(
                     _ => isBackfilling ? new Reloading(streamDefinition) : new Running(streamDefinition),
-                    ex => this.HandleError(ex, streamDefinition));
+                    ex => this.HandleError(ex, streamDefinition, isBackfilling));
         }
         catch (Exception ex)
         {
@@ -104,8 +106,13 @@ public class StreamingJobCommandHandler : ICommandHandler<StreamingJobCommand>
         }
     }
 
-    private UpdateStatusCommand HandleError(Exception exception, IStreamDefinition streamDefinition)
+    private UpdateStatusCommand HandleError(Exception exception, IStreamDefinition streamDefinition, bool isBackfilling)
     {
+        if (exception is HttpOperationException {Response.StatusCode: HttpStatusCode.Conflict })
+        {
+            this.logger.LogWarning(exception, "Streaming job with ID {streamId} already exists", streamDefinition.StreamId);
+            return isBackfilling ? new Reloading(streamDefinition) : new Running(streamDefinition);
+        }
         this.logger.LogError(exception, "Failed to send job");
         var condition = V1Alpha1StreamCondition.CustomErrorCondition($"Failed to start job: {exception.Message}");
         return new SetInternalErrorStatus(streamDefinition, condition);

--- a/test/Services/StreamingJobCommandHandlerTests.cs
+++ b/test/Services/StreamingJobCommandHandlerTests.cs
@@ -86,7 +86,7 @@ public class StreamingJobCommandHandlerTests(LoggerFixture loggerFixture) : ICla
                 It.IsAny<Func<JsonElement, It.IsAnyType>>()),
             Times.Once);
     }
-    
+
     [Theory]
     [InlineData(HttpStatusCode.Conflict, StreamPhase.RUNNING)]
     [InlineData(HttpStatusCode.InternalServerError, StreamPhase.FAILED)]
@@ -99,7 +99,7 @@ public class StreamingJobCommandHandlerTests(LoggerFixture loggerFixture) : ICla
         this.kubeClusterMock.Setup(k => k.SendJob(It.IsAny<V1Job>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.FromException<V1JobStatus>(new HttpOperationException
             {
-                Response = new HttpResponseMessageWrapper(new HttpResponseMessage{StatusCode = statusCode}, "")
+                Response = new HttpResponseMessageWrapper(new HttpResponseMessage { StatusCode = statusCode }, "")
             }));
         this.streamClassRepositoryMock
             .Setup(scr => scr.Get(It.IsAny<string>(), It.IsAny<string>()))


### PR DESCRIPTION
Fixes #110 

## Scope

Implemented:
- Operator will ignore HTTP Conflict status code.

Additional changes:
- Changed `V1Alpha1StreamStatus` from `class` to `record` because in C# records has built-in `.ToString()` implementation (for testing).

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.