### PR TITLE
Use the Recreate deployment strategy type

### DIFF
--- a/.helm/templates/deployment.yaml
+++ b/.helm/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       {{- include "app.selectorLabels" $ | nindent 6 }}
   # For now Arcane Operator supports only single replica
   replicas: 1
+  # The deployment strategy is hardcoded as well until the Arcane Operator is able to work in HA mode
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Resolves #121

## Scope

Implemented:
- The Arcane.Operator deployment will use the `Recreate` deployment strategy to avoid duplication of the operator in one cluster.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.