### PR TITLE
Fix the StreamClass restart behavior

### DIFF
--- a/src/Models/Resources/StreamClass/Base/IStreamClass.cs
+++ b/src/Models/Resources/StreamClass/Base/IStreamClass.cs
@@ -1,4 +1,6 @@
-﻿using k8s;
+﻿using System;
+using Akka.Streams;
+using k8s;
 using k8s.Models;
 using Snd.Sdk.Kubernetes;
 
@@ -52,4 +54,22 @@ public interface IStreamClass : IKubernetesObject<V1ObjectMeta>
     /// <param name="propertyName">Name of the property to test</param>
     /// <returns></returns>
     bool IsSecretRef(string propertyName);
+    
+    /// <summary>
+    /// Reads the restart settings for source that emits StreamDefinitionEvents for this StreamClass.
+    /// For now, it is a default value.
+    /// </summary>
+    /// <returns>Akka restart settings instance.</returns>
+    public RestartSettings RestartSettings => DefaultRestartSettings;
+
+    /// <summary>
+    /// Default restart settings for the StreamClass.
+    /// Minimum backoff is 1 second.
+    /// Maximum backoff is 30 seconds.
+    /// Random factor is 0.2 adds 20% "noise" to vary the intervals slightly.
+    /// Maximum number of restarts is 20 restarts within 10 minutes.
+    /// </summary>
+    private static RestartSettings DefaultRestartSettings =>
+        RestartSettings.Create(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30), 0.2)
+        .WithMaxRestarts(20, TimeSpan.FromMinutes(10));
 }

--- a/src/Models/Resources/StreamClass/Base/IStreamClass.cs
+++ b/src/Models/Resources/StreamClass/Base/IStreamClass.cs
@@ -54,7 +54,7 @@ public interface IStreamClass : IKubernetesObject<V1ObjectMeta>
     /// <param name="propertyName">Name of the property to test</param>
     /// <returns></returns>
     bool IsSecretRef(string propertyName);
-    
+
     /// <summary>
     /// Reads the restart settings for source that emits StreamDefinitionEvents for this StreamClass.
     /// For now, it is a default value.

--- a/src/Services/Operators/StreamClassOperatorService.cs
+++ b/src/Services/Operators/StreamClassOperatorService.cs
@@ -9,7 +9,6 @@ using Arcane.Operator.Configurations;
 using Arcane.Operator.Models.Api;
 using Arcane.Operator.Models.Commands;
 using Arcane.Operator.Models.Resources.StreamClass.Base;
-using Arcane.Operator.Services.Base;
 using Arcane.Operator.Services.Base.CommandHandlers;
 using Arcane.Operator.Services.Base.Metrics;
 using Arcane.Operator.Services.Base.Operators;
@@ -25,7 +24,7 @@ namespace Arcane.Operator.Services.Operators;
 /// <inheritdoc cref="IStreamClassOperatorService"/>
 public class StreamClassOperatorService : IStreamClassOperatorService
 {
-    private const int parallelism = 1;
+    private const int PARALLELISM = 1;
 
     private readonly StreamClassOperatorServiceConfiguration configuration;
 
@@ -61,7 +60,7 @@ public class StreamClassOperatorService : IStreamClassOperatorService
     /// <inheritdoc cref="IStreamClassOperatorService.GetStreamClassEventsGraph"/>
     public IRunnableGraph<Task> GetStreamClassEventsGraph(CancellationToken cancellationToken)
     {
-        var sink = Sink.ForEachAsync<SetStreamClassStatusCommand>(parallelism, command =>
+        var sink = Sink.ForEachAsync<SetStreamClassStatusCommand>(PARALLELISM, command =>
         {
             this.streamClassStatusCommandHandler.Handle(command);
             return this.streamClassRepository.InsertOrUpdate(command.streamClass, command.phase, command.conditions, command.request.PluralName);
@@ -92,10 +91,10 @@ public class StreamClassOperatorService : IStreamClassOperatorService
         return new SetStreamClassReady(streamClass.Name(), this.request, streamClass);
     }
 
-    private SetStreamClassStopped Detach(IStreamClass streamClass)
+    private Option<SetStreamClassStatusCommand> Detach(IStreamClass streamClass)
     {
         this.streamOperatorService.Detach(streamClass);
-        return new SetStreamClassStopped(streamClass.Name(), this.request, streamClass);
+        return Option<SetStreamClassStatusCommand>.None;
     }
 
     private Directive HandleError(Exception exception)

--- a/src/Services/Operators/StreamOperatorService.cs
+++ b/src/Services/Operators/StreamOperatorService.cs
@@ -74,23 +74,23 @@ public sealed class StreamOperatorService : IStreamOperatorService, IDisposable
 
     public void Attach(IStreamClass streamClass)
     {
-        if(this.killSwitches.ContainsKey(streamClass.ToStreamClassId()))
+        if (this.killSwitches.ContainsKey(streamClass.ToStreamClassId()))
         {
             return;
         }
-        
+
         var request = new CustomResourceApiRequest(
             streamClass.Namespace(),
             streamClass.ApiGroupRef,
             streamClass.VersionRef,
             streamClass.PluralNameRef
         );
-        
+
 
         var restartSource = RestartSource
-            .WithBackoff(() => this.streamDefinitionSource.GetEvents(request, streamClass.MaxBufferCapacity),streamClass.RestartSettings)
+            .WithBackoff(() => this.streamDefinitionSource.GetEvents(request, streamClass.MaxBufferCapacity), streamClass.RestartSettings)
             .ViaMaterialized(KillSwitches.Single<ResourceEvent<IStreamDefinition>>(), Keep.Right);
-            
+
         var ks = restartSource
             .Recover(cause =>
             {

--- a/test/Services/StreamClassOperatorServiceTests.cs
+++ b/test/Services/StreamClassOperatorServiceTests.cs
@@ -233,7 +233,6 @@ public class StreamClassOperatorServiceTests : IClassFixture<LoggerFixture>, ICl
             .AddSingleton<IStreamOperatorService, StreamOperatorService>()
             .AddSingleton<ICommandHandler<UpdateStatusCommand>, UpdateStatusCommandHandler>()
             .AddSingleton<ICommandHandler<SetStreamClassStatusCommand>, UpdateStatusCommandHandler>()
-            .AddSingleton<ICommandHandler<RemoveAnnotationCommand<IStreamDefinition>>, AnnotationCommandHandler>()
             .AddSingleton<ICommandHandler<SetAnnotationCommand<V1Job>>, AnnotationCommandHandler>()
             .AddSingleton<ICommandHandler<StreamingJobCommand>, StreamingJobCommandHandler>()
             .AddSingleton<IMetricsReporter, MetricsReporter>()


### PR DESCRIPTION
Resolves #114

## Scope

Implemented:
- Fixed the restart behavior: the StreamDefinition listener for a stream class will try to restart with backoff if subscription was not successful).
- Fixed the StreamClass deletion event: Operator will not try to set the status for a deleted StreamClass object.
- Fixed the memory issue: The StreamClassOperator service will not recreate SD listener if it was already started.

Additional changes:
- Removed not used `removeAnnotationCommandHandler` from the `StreamOperatorService` class.
-  Minor codestyle fixes.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.