### PR TITLE
Add the crash loop metrics to Arcane.Operator

### DIFF
--- a/src/Configurations/CrashLoopMetricsReporterConfiguration.cs
+++ b/src/Configurations/CrashLoopMetricsReporterConfiguration.cs
@@ -1,0 +1,13 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Arcane.Operator.Services.Metrics;
+
+namespace Arcane.Operator.Configurations;
+
+/// <summary>
+/// Configuration for the <see cref="MetricsReporter"/> class.
+/// </summary>
+[ExcludeFromCodeCoverage(Justification = "Model")]
+public class CrashLoopMetricsReporterConfiguration
+{
+    public MetricsPublisherActorConfiguration MetricsPublisherActorConfiguration { get; set; }
+};

--- a/src/Services/Base/Metrics/ICrashLoopReporterService.cs
+++ b/src/Services/Base/Metrics/ICrashLoopReporterService.cs
@@ -14,7 +14,7 @@ public interface ICrashLoopReporterService
     /// <param name="streamId">The id of the affected stream.</param>
     /// <param name="metricTags">Metric tags</param>
     void AddCrashLoopEvent(string streamId, SortedDictionary<string, string> metricTags);
-    
+
     /// <summary>
     /// Removes the crash loop event from the metrics reporter
     /// </summary>

--- a/src/Services/Base/Metrics/ICrashLoopReporterService.cs
+++ b/src/Services/Base/Metrics/ICrashLoopReporterService.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Arcane.Operator.Services.Metrics.Actors;
+
+namespace Arcane.Operator.Services.Base.Metrics;
+
+/// <summary>
+/// Wrapper for the <see cref="CrashLoopMetricsPublisherActor"/>
+/// </summary>
+public interface ICrashLoopReporterService
+{
+    /// <summary>
+    /// Adds the crash loop event to the metrics reporter
+    /// </summary>
+    /// <param name="streamId">The id of the affected stream.</param>
+    /// <param name="metricTags">Metric tags</param>
+    void AddCrashLoopEvent(string streamId, SortedDictionary<string, string> metricTags);
+    
+    /// <summary>
+    /// Removes the crash loop event from the metrics reporter
+    /// </summary>
+    /// <param name="streamId">The id of the affected stream.</param>
+    void RemoveCrashLoopEvent(string streamId);
+}

--- a/src/Services/Metrics/Actors/CrashLoopMetricsPublisherActor.cs
+++ b/src/Services/Metrics/Actors/CrashLoopMetricsPublisherActor.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.Event;
+using Arcane.Operator.Configurations;
+using Snd.Sdk.Metrics.Base;
+
+namespace Arcane.Operator.Services.Metrics.Actors;
+
+/// <summary>
+/// Add stream class metrics message. Once received, the metrics will be added to the
+/// metrics collection in the actor.
+/// </summary>
+/// <param name="MetricName">Name of the stream kind referenced by the stream class</param>
+/// <param name="MetricTags">Name of the metric to report</param>
+/// <param name="MetricTags">Tags of the metric to report</param>
+public record AddSCrashLoopMetricsMessage(string StreamId, string MetricName,
+    SortedDictionary<string, string> MetricTags);
+
+
+/// <summary>
+/// Remove stream class metrics message. Once received, the metrics will be removed from the 
+/// metrics collection in the actor.
+/// </summary>
+/// <param name="StreamId">Name of the stream kind referenced by the stream class</param>
+public record RemoveCrashLoopMetricsMessage(string StreamId);
+
+
+/// <summary>
+/// Emit metrics message. Once received, the metrics will be emitted to the metrics service.
+/// This message is emitted periodically by the <see cref="CrashLoopMetricsPublisherActor"/> actor.
+/// </summary>
+public record EmitCrashLoopMetricsMessage;
+
+/// <summary>
+/// A metric collection element for a stream.
+/// </summary>
+public record CrashLoopMetric(string MetricName, SortedDictionary<string, string> MetricTags, int MetricValue);
+
+
+/// <summary>
+/// This actor is responsible for collecting metrics representing the number of streams in the crash loop stage.
+/// </summary>
+public class CrashLoopMetricsPublisherActor : ReceiveActor, IWithTimers
+{
+    public ITimerScheduler Timers { get; set; }
+    private readonly Dictionary<string, CrashLoopMetric> streamClassMetrics = new();
+    private readonly ILoggingAdapter Log = Context.GetLogger();
+    private readonly MetricsPublisherActorConfiguration configuration;
+
+    public CrashLoopMetricsPublisherActor(MetricsPublisherActorConfiguration configuration, MetricsService metricsService)
+    {
+        this.configuration = configuration;
+        this.Receive<AddSCrashLoopMetricsMessage>(s =>
+        {
+            if (s.MetricTags == null || s.MetricName == null || s.StreamId == null)
+            {
+                this.Log.Warning("Skip malformed {messageName} for {key} with value: {@message}",
+                    nameof(AddSCrashLoopMetricsMessage),
+                    s.StreamId,
+                    s);
+                return;
+            }
+            this.Log.Debug("Adding crash loop metric for {streamId}", s.StreamId);
+            this.streamClassMetrics[s.StreamId] = new CrashLoopMetric(s.MetricName, s.MetricTags, 1);
+        });
+
+        this.Receive<RemoveCrashLoopMetricsMessage>(s =>
+        {
+            if (!this.streamClassMetrics.Remove(s.StreamId))
+            {
+                this.Log.Warning("Stream class {streamId} not found in metrics collection", s.StreamId);
+            }
+        });
+
+        this.Receive<EmitCrashLoopMetricsMessage>(_ =>
+        {
+            this.Log.Debug("Start emitting crash loop metrics");
+            foreach (var (_, metric) in this.streamClassMetrics)
+            {
+                try
+                {
+                    metricsService.Count(metric.MetricName, metric.MetricValue, metric.MetricTags);
+                }
+                catch (Exception exception)
+                {
+                    this.Log.Error(exception, "Failed to publish metrics for {key}", metric.MetricName);
+                }
+            }
+        });
+    }
+
+    protected override void PreStart()
+    {
+        this.Timers.StartPeriodicTimer(nameof(EmitCrashLoopMetricsMessage),
+            new EmitCrashLoopMetricsMessage(),
+            this.configuration.InitialDelay,
+            this.configuration.UpdateInterval);
+    }
+}

--- a/src/Services/Metrics/CrashLoopReporterService.cs
+++ b/src/Services/Metrics/CrashLoopReporterService.cs
@@ -26,7 +26,7 @@ public class CrashLoopReporterService : ICrashLoopReporterService
     {
         this.statusActor.Tell(new AddSCrashLoopMetricsMessage(streamId, METRIC_NAME, metricTags));
     }
-    
+
     public void RemoveCrashLoopEvent(string streamId)
     {
         this.statusActor.Tell(new RemoveCrashLoopMetricsMessage(streamId));

--- a/src/Services/Metrics/CrashLoopReporterService.cs
+++ b/src/Services/Metrics/CrashLoopReporterService.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Akka.Actor;
+using Arcane.Operator.Configurations;
+using Arcane.Operator.Services.Base.Metrics;
+using Arcane.Operator.Services.Metrics.Actors;
+using Microsoft.Extensions.Options;
+using Snd.Sdk.Metrics.Base;
+
+namespace Arcane.Operator.Services.Metrics;
+
+public class CrashLoopReporterService : ICrashLoopReporterService
+{
+    private readonly IActorRef statusActor;
+    private const string METRIC_NAME = "crash_loop";
+
+    public CrashLoopReporterService(MetricsService metricsService, ActorSystem actorSystem,
+        IOptions<CrashLoopMetricsReporterConfiguration> metricsReporterConfiguration)
+    {
+        this.statusActor = actorSystem.ActorOf(Props.Create(() => new CrashLoopMetricsPublisherActor(
+                metricsReporterConfiguration.Value.MetricsPublisherActorConfiguration,
+                metricsService)),
+            nameof(CrashLoopMetricsPublisherActor));
+    }
+
+    public void AddCrashLoopEvent(string streamId, SortedDictionary<string, string> metricTags)
+    {
+        this.statusActor.Tell(new AddSCrashLoopMetricsMessage(streamId, METRIC_NAME, metricTags));
+    }
+    
+    public void RemoveCrashLoopEvent(string streamId)
+    {
+        this.statusActor.Tell(new RemoveCrashLoopMetricsMessage(streamId));
+    }
+}

--- a/src/Services/Metrics/DeclaredMetrics.cs
+++ b/src/Services/Metrics/DeclaredMetrics.cs
@@ -23,7 +23,7 @@ public static class DeclaredMetrics
         { $"{TAG_PREFIX}/kind", job.Kind },
         { $"{TAG_PREFIX}/name", job.Name() },
     };
-    
+
     public static SortedDictionary<string, string> GetCrashLoopMetricsTags(this IStreamDefinition streamDefinition) => new()
     {
         { $"{TAG_PREFIX}/namespace", streamDefinition.Namespace() },

--- a/src/Services/Metrics/DeclaredMetrics.cs
+++ b/src/Services/Metrics/DeclaredMetrics.cs
@@ -2,6 +2,7 @@
 using Arcane.Operator.Extensions;
 using Arcane.Operator.Models;
 using Arcane.Operator.Models.Commands;
+using Arcane.Operator.Models.StreamDefinitions.Base;
 using k8s;
 using k8s.Models;
 using Snd.Sdk.Helpers;
@@ -21,6 +22,13 @@ public static class DeclaredMetrics
         { $"{TAG_PREFIX}/namespace", job.Namespace() },
         { $"{TAG_PREFIX}/kind", job.Kind },
         { $"{TAG_PREFIX}/name", job.Name() },
+    };
+    
+    public static SortedDictionary<string, string> GetCrashLoopMetricsTags(this IStreamDefinition streamDefinition) => new()
+    {
+        { $"{TAG_PREFIX}/namespace", streamDefinition.Namespace() },
+        { $"{TAG_PREFIX}/kind", streamDefinition.Kind },
+        { $"{TAG_PREFIX}/stream_id", streamDefinition.Name() },
     };
 
     public static SortedDictionary<string, string> GetMetricsTags(this V1Job job) => new()

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -79,6 +79,7 @@ public class Startup
         // Register the metrics providers
         services.AddDatadogMetrics(DatadogConfiguration.UnixDomainSocket(AppDomain.CurrentDomain.FriendlyName));
         services.AddSingleton<IMetricsReporter, MetricsReporter>();
+        services.AddSingleton<ICrashLoopReporterService, CrashLoopReporterService>();
 
         // Register additional services
         services.AddLocalActorSystem();

--- a/test/Arcane.Operator.Tests.csproj
+++ b/test/Arcane.Operator.Tests.csproj
@@ -14,7 +14,9 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.4.1"/>
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="Akka.TestKit" Version="1.5.23"/>
+        <PackageReference Include="Akka.TestKit.Xunit2" Version="1.5.23"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/test/Services/CrashLoopMetricsPublisherActorTests.cs
+++ b/test/Services/CrashLoopMetricsPublisherActorTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.TestKit.Xunit2;
+using Arcane.Operator.Configurations;
+using Arcane.Operator.Services.Metrics.Actors;
+using Moq;
+using Snd.Sdk.Metrics.Base;
+using Xunit;
+
+namespace Arcane.Operator.Tests.Services;
+
+public class CrashLoopMetricsPublisherActorTests : TestKit
+{
+    // Akka service and test helpers
+    private readonly TaskCompletionSource tcs = new();
+    private readonly CancellationTokenSource cts = new();
+
+
+    // Mocks
+    private readonly Mock<MetricsService> metricsServiceMock = new();
+
+    public CrashLoopMetricsPublisherActorTests()
+    {
+        this.cts.CancelAfter(TimeSpan.FromSeconds(5));
+        this.cts.Token.Register(this.tcs.SetResult);
+    }
+
+    [Fact]
+    public async Task TestMetricsAdded()
+    {
+        // Arrange
+        this.metricsServiceMock.Setup(ms => ms.Count(It.IsAny<string>(),
+            It.IsAny<int>(),
+            It.IsAny<SortedDictionary<string, string>>())).Callback(() => this.tcs.TrySetResult());
+        var subject = this.CreateSubject(null);
+
+        // Act
+        subject.Tell(new AddSCrashLoopMetricsMessage("test", "test", new()));
+        subject.Tell(new AddSCrashLoopMetricsMessage("test2", "test", new()));
+        subject.Tell(new EmitCrashLoopMetricsMessage());
+        await this.tcs.Task;
+
+        // Assert
+        this.metricsServiceMock.Verify(ms => ms.Count(It.IsAny<string>(),
+            It.IsAny<int>(),
+            It.IsAny<SortedDictionary<string, string>>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task TestBrokenMetricsService()
+    {
+        // Arrange
+        this.metricsServiceMock.Setup(ms => ms.Count(It.IsAny<string>(),
+            It.IsAny<int>(),
+            It.IsAny<SortedDictionary<string, string>>())).Callback(() => this.tcs.TrySetResult());
+        this.metricsServiceMock.Setup(ms => ms.Count(It.IsAny<string>(),
+            It.IsAny<int>(),
+            It.IsAny<SortedDictionary<string, string>>())).Throws(new Exception("Test exception"));
+
+        var subject = this.CreateSubject(null);
+
+        // Act
+        subject.Tell(new AddSCrashLoopMetricsMessage("test", "test", new()));
+        subject.Tell(new EmitCrashLoopMetricsMessage());
+        subject.Tell(new EmitCrashLoopMetricsMessage());
+        await this.tcs.Task;
+
+        // Assert
+        this.metricsServiceMock.Verify(ms => ms.Count(It.IsAny<string>(),
+            It.IsAny<int>(),
+            It.IsAny<SortedDictionary<string, string>>()), Times.AtLeast(2));
+    }
+
+    [Fact]
+    public async Task TestRemoveMetricsMessage()
+    {
+        // Arrange
+        var subject = this.CreateSubject(this.tcs);
+
+        // Act
+        subject.Tell(new AddSCrashLoopMetricsMessage("test", "test", new()));
+        subject.Tell(new EmitCrashLoopMetricsMessage());
+        subject.Tell(new RemoveCrashLoopMetricsMessage("test"));
+        subject.Tell(new EmitCrashLoopMetricsMessage());
+        subject.Tell(PoisonPill.Instance);
+        await this.tcs.Task;
+
+        // Assert
+        this.metricsServiceMock.Verify(ms => ms.Count(It.IsAny<string>(),
+            It.IsAny<int>(),
+            It.IsAny<SortedDictionary<string, string>>()), Times.Exactly(1));
+    }
+
+    [Fact]
+    public async Task TestRemoveNonExisingMetric()
+    {
+        // Arrange
+        var subject = this.CreateSubject(this.tcs);
+
+        // Act
+        subject.Tell(new AddSCrashLoopMetricsMessage("test", "test", new()));
+        subject.Tell(new EmitCrashLoopMetricsMessage());
+        subject.Tell(new RemoveCrashLoopMetricsMessage("not-exists"));
+        subject.Tell(new EmitCrashLoopMetricsMessage());
+        subject.Tell(PoisonPill.Instance);
+        await this.tcs.Task;
+
+        // Assert
+        this.metricsServiceMock.Verify(ms => ms.Count(It.IsAny<string>(),
+            It.IsAny<int>(),
+            It.IsAny<SortedDictionary<string, string>>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task TestBrokenMessage()
+    {
+        // Arrange
+        var subject = this.CreateSubject(this.tcs);
+
+        // Act
+        subject.Tell(new AddSCrashLoopMetricsMessage("test", "test", new()));
+        subject.Tell(new AddSCrashLoopMetricsMessage(null, null, null));
+        subject.Tell(new EmitCrashLoopMetricsMessage());
+        subject.Tell(PoisonPill.Instance);
+        await this.tcs.Task;
+
+        // Assert
+        this.metricsServiceMock.Verify(ms => ms.Count(It.IsAny<string>(),
+            It.IsAny<int>(),
+            It.IsAny<SortedDictionary<string, string>>()), Times.Exactly(1));
+    }
+
+    private IActorRef CreateSubject(TaskCompletionSource taskCompletionSource)
+    {
+        var config = new MetricsPublisherActorConfiguration
+        {
+            InitialDelay = TimeSpan.Zero,
+            UpdateInterval = TimeSpan.FromSeconds(10),
+        };
+        return this.Sys.ActorOf(Props.Create(() =>
+            new TestMetricsPublisherActor(config, this.metricsServiceMock.Object, taskCompletionSource)));
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        this.cts?.Dispose();
+    }
+
+    private class TestMetricsPublisherActor(
+        MetricsPublisherActorConfiguration configuration,
+        MetricsService metricsService,
+        TaskCompletionSource tcs)
+        : CrashLoopMetricsPublisherActor(configuration, metricsService)
+    {
+        protected override void PostStop()
+        {
+            tcs?.TrySetResult();
+        }
+    }
+}

--- a/test/Services/CrashLoopMetricsPublisherActorTests.cs
+++ b/test/Services/CrashLoopMetricsPublisherActorTests.cs
@@ -24,7 +24,7 @@ public class CrashLoopMetricsPublisherActorTests : TestKit
 
     public CrashLoopMetricsPublisherActorTests()
     {
-        this.cts.CancelAfter(TimeSpan.FromSeconds(5));
+        this.cts.CancelAfter(TimeSpan.FromSeconds(10));
         this.cts.Token.Register(this.tcs.SetResult);
     }
 
@@ -35,7 +35,7 @@ public class CrashLoopMetricsPublisherActorTests : TestKit
         this.metricsServiceMock.Setup(ms => ms.Count(It.IsAny<string>(),
             It.IsAny<int>(),
             It.IsAny<SortedDictionary<string, string>>())).Callback(() => this.tcs.TrySetResult());
-        var subject = this.CreateSubject(null);
+        var subject = this.CreateSubject(this.tcs);
 
         // Act
         subject.Tell(new AddSCrashLoopMetricsMessage("test", "test", new()));

--- a/test/Services/StreamClassOperatorServiceTests.cs
+++ b/test/Services/StreamClassOperatorServiceTests.cs
@@ -248,6 +248,7 @@ public class StreamClassOperatorServiceTests : IClassFixture<LoggerFixture>, ICl
                 MaxBufferCapacity = 100
             }))
             .AddSingleton<IStreamClassOperatorService, StreamClassOperatorService>()
+            .AddSingleton(Mock.Of<ICrashLoopReporterService>())
             .BuildServiceProvider();
     }
 }

--- a/test/Services/StreamOperatorServiceTests.cs
+++ b/test/Services/StreamOperatorServiceTests.cs
@@ -298,14 +298,14 @@ public class StreamOperatorServiceTests : IClassFixture<LoggerFixture>, IDisposa
                 => service.SendJob(It.Is<V1Job>(job => job.IsBackfilling()), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Exactly(expectStart ? 1 : 0));
     }
-    
-    
+
+
     public static IEnumerable<object[]> GenerateCrashLoopTestCases()
     {
         yield return new object[] { WatchEventType.Added, CrashLoopStreamDefinition, true };
         yield return new object[] { WatchEventType.Modified, CrashLoopStreamDefinition, true };
         yield return new object[] { WatchEventType.Deleted, CrashLoopStreamDefinition, false };
-        
+
         yield return new object[] { WatchEventType.Added, StreamDefinitionTestCases.StreamDefinition, false };
         yield return new object[] { WatchEventType.Modified, StreamDefinitionTestCases.StreamDefinition, false };
         yield return new object[] { WatchEventType.Deleted, StreamDefinitionTestCases.StreamDefinition, false };
@@ -331,11 +331,11 @@ public class StreamOperatorServiceTests : IClassFixture<LoggerFixture>, IDisposa
         // Assert
         if (expectMetricAdded)
         {
-            this.crashLoopReporterServiceMock.Verify( m => m.AddCrashLoopEvent(streamDefinition.StreamId, It.IsAny<SortedDictionary<string, string>>()));
+            this.crashLoopReporterServiceMock.Verify(m => m.AddCrashLoopEvent(streamDefinition.StreamId, It.IsAny<SortedDictionary<string, string>>()));
         }
         else
         {
-            this.crashLoopReporterServiceMock.Verify( m => m.RemoveCrashLoopEvent(streamDefinition.StreamId));
+            this.crashLoopReporterServiceMock.Verify(m => m.RemoveCrashLoopEvent(streamDefinition.StreamId));
         }
     }
 

--- a/test/Services/TestCases/StreamDefinitionTestCases.cs
+++ b/test/Services/TestCases/StreamDefinitionTestCases.cs
@@ -54,6 +54,20 @@ public static class StreamDefinitionTestCases
             }
         }
     };
+    
+    public static IStreamDefinition CrashLoopStreamDefinition => new StreamDefinition
+    {
+        Spec = JsonDocument.Parse(StreamSpec).RootElement,
+        Kind = Kind,
+        Metadata = new V1ObjectMeta
+        {
+            Name = "stream",
+            Annotations = new Dictionary<string, string>
+            {
+                { Annotations.STATE_ANNOTATION_KEY, Annotations.CRASH_LOOP_STATE_ANNOTATION_VALUE }
+            }
+        }
+    };
 
     public static FailedStreamDefinition FailedStreamDefinition(Exception exception)
     {

--- a/test/Services/TestCases/StreamDefinitionTestCases.cs
+++ b/test/Services/TestCases/StreamDefinitionTestCases.cs
@@ -54,7 +54,7 @@ public static class StreamDefinitionTestCases
             }
         }
     };
-    
+
     public static IStreamDefinition CrashLoopStreamDefinition => new StreamDefinition
     {
         Spec = JsonDocument.Parse(StreamSpec).RootElement,


### PR DESCRIPTION
Resolves #134

## Scope

Implemented:
- Added an actor that periodically reports a value `1` if any stream has a crash loop status.

Since we are moving from .net to golang for the development of Arcane operator, I did not merge #125, just created a new actor like the actor that used for stream classes.


## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.