### PR TITLE
Fix the coverage tool version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Check test coverage
         if: false # Temporarily disable integration tests
         id: coverage
-        uses: vladopajic/go-test-coverage@v2.18.0
+        uses: vladopajic/go-test-coverage@v2.18.1
         continue-on-error: true # Should fail after coverage comment is posted
         with:
           config: .testcoverage.yaml


### PR DESCRIPTION
The action for some reason cannot download code coverage tool.
This PR bumps the tool version to fix errors like that:
<img width="765" height="289" alt="image" src="https://github.com/user-attachments/assets/d718c89c-fbf7-4f3c-8aee-ccd6f698a7df" />


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.