### PR TITLE
Allow dependabot write PR comments

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      pull-requests: write  # Allows creation of PR comments
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Part of #144 

## Scope

Implemented:
- Grant permission for Dependabot to write comments on PRs.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.