### PR TITLE
Bump arcane-crd in tests

### DIFF
--- a/integration_tests/helm/setup/Chart.lock
+++ b/integration_tests/helm/setup/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: arcane-crd
   repository: oci://ghcr.io/sneaksanddata/helm
-  version: v0.0.5
-digest: sha256:c3d9e7c8ceece27154a5214f03e085482059992d7055b622ff1ffb318a685588
-generated: "2026-01-27T11:03:04.940621+01:00"
+  version: v0.0.7
+digest: sha256:791f370431f48eccb5a5108dc8e243d783f669fe1d218afe761284892256857d
+generated: "2026-02-09T11:51:49.53797+01:00"

--- a/integration_tests/helm/setup/Chart.yaml
+++ b/integration_tests/helm/setup/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.0.0
 appVersion: "0.0.0"
 dependencies:
   - name: arcane-crd
-    version: v0.0.5
+    version: v0.0.7
     repository: oci://ghcr.io/sneaksanddata/helm

--- a/pkg/apis/streaming/v1/types.go
+++ b/pkg/apis/streaming/v1/types.go
@@ -105,6 +105,7 @@ type BackfillRequestSpec struct {
 	StreamId string `json:"streamId"`
 
 	// Completed indicates whether the backfill request has been completed
+	// +kubebuilder:default=false
 	Completed bool `json:"completed,omitempty"`
 }
 
@@ -125,6 +126,8 @@ type BackfillRequestStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="StreamClass",type=string,JSONPath=`.spec.streamClass`
 // +kubebuilder:printcolumn:name="StreamId",type=string,JSONPath=`.spec.streamId`
+// +kubebuilder:printcolumn:name="Completed",type=string,JSONPath=`.spec.completed`
+// +kubebuilder:selectablefield:JSONPath=.spec.completed
 type BackfillRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Next step of https://github.com/SneaksAndData/arcane-crd/pull/12

## Scope

Implemented:
- Added `.spec.completed` of backfill request to to additional printer fields.
- Added the default value `false` to that field. It will look better in the UI
 
## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.