### PR TITLE
Use the context from the signal handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,7 +120,11 @@ func main() {
 		panic(err)
 	}
 
-	err = mgr.Start(context.Background())
+	err = mgr.Start(ctx)
+	if errors.Is(err, context.Canceled) {
+		logger.V(0).Info("App stopped due to context cancellation")
+		return
+	}
 	if err != nil {
 		setupLog.V(0).Error(err, "problem running manager")
 		panic(err)


### PR DESCRIPTION
## Scope

Implemented:
- Controller manager now uses the context that can be cancelled by a signal for cancellation. This should fix the stopping issues.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.