### PR TITLE
Fix incorrect documentation

### DIFF
--- a/docs/user_scenarios.md
+++ b/docs/user_scenarios.md
@@ -21,8 +21,6 @@ This will stop the streaming job and prevent it from processing any new data.
 To start backfill for an existing stream, you need to create a backfill request custom resource (CR) that references the stream.
 The backfill request will be picked up by the operator, which will create a Kubernetes job to run the backfill process.
 
-If the stream **is suspended**, you need to create backfill request first and then unsuspend the stream.
-
 Example backfill request:
 ```yaml
 apiVersion: streaming.sneaksanddata.com/v1


### PR DESCRIPTION
This PR fixes the documentation.

Description of backfill process assumes that the user must unsuspend the suspended stream manually if they created a BFR, which is not true.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.