### PR TITLE
Extract status manager

### DIFF
--- a/services/controllers/stream/backend_resource_manager.go
+++ b/services/controllers/stream/backend_resource_manager.go
@@ -18,7 +18,7 @@ import (
 type BackendResourceManager interface {
 
 	// SetupWithController sets up the necessary watches and handlers for the backend resources with the provided controller.
-	SetupWithController(cache cache.Cache, scheme *runtime.Scheme, mapper meta.RESTMapper, controller controller.Controller, manager PhaseManager, primaryGvk schema.GroupVersionKind) error
+	SetupWithController(cache cache.Cache, scheme *runtime.Scheme, mapper meta.RESTMapper, controller controller.Controller, primaryGvk schema.GroupVersionKind) error
 
 	// Get retrieves the current state of the backend resource associated with the given stream definition.
 	Get(ctx context.Context, key client.ObjectKey) (*StreamingJob, error)
@@ -28,4 +28,7 @@ type BackendResourceManager interface {
 
 	// Apply creates or updates the backend resource based on the provided stream definition and backfill request, and updates the stream phase accordingly.
 	Apply(ctx context.Context, definition Definition, backfillRequest *v1.BackfillRequest, nextPhase Phase, streamClass *v1.StreamClass, eventFunc controllers.EventFunc) (reconcile.Result, error)
+
+	// NoOp Does not perform any changes, but updates the stream status.
+	NoOp(ctx context.Context, definition Definition, backfillRequest *v1.BackfillRequest, nextPhase Phase, eventFunc controllers.EventFunc) (reconcile.Result, error)
 }

--- a/services/controllers/stream/default_status_manager.go
+++ b/services/controllers/stream/default_status_manager.go
@@ -1,0 +1,87 @@
+package stream
+
+import (
+	"context"
+
+	v1 "github.com/SneaksAndData/arcane-operator/pkg/apis/streaming/v1"
+	"github.com/SneaksAndData/arcane-operator/services/controllers"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ StatusManager = (*DefaultStatusManager)(nil)
+
+type DefaultStatusManager struct {
+	gvk              schema.GroupVersionKind
+	client           client.Client
+	streamClass      *v1.StreamClass
+	definitionParser DefinitionParser
+}
+
+func NewDefaultStatusManager(client client.Client, gvk schema.GroupVersionKind, streamClass *v1.StreamClass, definitionParser DefinitionParser) *DefaultStatusManager {
+	return &DefaultStatusManager{
+		gvk:              gvk,
+		client:           client,
+		streamClass:      streamClass,
+		definitionParser: definitionParser,
+	}
+}
+
+func (s *DefaultStatusManager) UpdateStreamPhase(ctx context.Context, definition Definition, backfillRequest *v1.BackfillRequest, next Phase, eventFunc controllers.EventFunc) (reconcile.Result, error) {
+	logger := s.getLogger(ctx, definition.NamespacedName())
+
+	if definition.GetPhase() == next { // coverage-ignore
+		logger.V(1).Info("Stream phase is already set", "phase", definition.GetPhase())
+		return reconcile.Result{}, nil
+	}
+
+	logger.V(0).Info("updating Stream status", "from", definition.GetPhase(), "to", next)
+
+	// Refetch the definition to ensure we have the latest version before updating status
+	definition, err := GetStreamForClass(ctx, s.client, s.streamClass, definition.NamespacedName(), s.definitionParser)
+	if err != nil {
+		logger.V(0).Error(err, "unable to fetch Stream for status update")
+		return reconcile.Result{}, err
+	}
+	err = definition.SetPhase(next)
+	if err != nil { // coverage-ignore
+		logger.V(0).Error(err, "unable to set Stream status")
+		return reconcile.Result{}, err
+	}
+
+	err = definition.RecomputeConfiguration(backfillRequest)
+	if err != nil { // coverage-ignore
+		logger.V(0).Error(err, "unable to recompute Stream configuration hash")
+		return reconcile.Result{}, err
+	}
+
+	err = definition.SetConditions(definition.ComputeConditions(backfillRequest))
+
+	if err != nil { // coverage-ignore
+		logger.V(0).Error(err, "unable to set Stream conditions")
+		return reconcile.Result{}, err
+	}
+
+	statusUpdate := definition.ToUnstructured().DeepCopy()
+	err = s.client.Status().Update(ctx, statusUpdate)
+	if err != nil { // coverage-ignore
+		logger.V(1).Error(err, "unable to update Stream status")
+		return reconcile.Result{}, err
+	}
+
+	if eventFunc != nil {
+		eventFunc()
+	}
+
+	return reconcile.Result{}, nil
+
+}
+
+func (s *DefaultStatusManager) getLogger(_ context.Context, request types.NamespacedName) klog.Logger {
+	return klog.Background().
+		WithName("StreamReconciler").
+		WithValues("namespace", request.Namespace, "streamId", request.Name, "streamKind", s.gvk.Kind)
+}

--- a/services/controllers/stream/job_backend.go
+++ b/services/controllers/stream/job_backend.go
@@ -30,12 +30,12 @@ var _ BackendResourceManager = (*JobBackend)(nil)
 
 type JobBackend struct {
 	client        client.Client
-	phaseManager  PhaseManager
+	phaseManager  StatusManager
 	jobBuilder    JobBuilder
 	eventRecorder record.EventRecorder
 }
 
-func NewJobBackend(client client.Client, jobBuilder JobBuilder, eventRecorder record.EventRecorder, phaseManager PhaseManager) *JobBackend {
+func NewJobBackend(client client.Client, jobBuilder JobBuilder, eventRecorder record.EventRecorder, phaseManager StatusManager) *JobBackend {
 	return &JobBackend{
 		client:        client,
 		jobBuilder:    jobBuilder,
@@ -44,10 +44,9 @@ func NewJobBackend(client client.Client, jobBuilder JobBuilder, eventRecorder re
 	}
 }
 
-func (j *JobBackend) SetupWithController(cache cache.Cache, scheme *runtime.Scheme, mapper meta.RESTMapper, controller controller.Controller, manager PhaseManager, primaryGvk schema.GroupVersionKind) error {
+func (j *JobBackend) SetupWithController(cache cache.Cache, scheme *runtime.Scheme, mapper meta.RESTMapper, controller controller.Controller, primaryGvk schema.GroupVersionKind) error {
 	primaryResource := &unstructured.Unstructured{}
 	primaryResource.SetGroupVersionKind(primaryGvk)
-	j.phaseManager = manager
 	return watchers.NewTypedSecondaryWatcherBuilder[*batchv1.Job]().
 		WithFilter(NewJobFilter()).
 		WithCache(cache).
@@ -139,6 +138,10 @@ func (j *JobBackend) Remove(ctx context.Context, definition Definition, nextPhas
 
 	return j.phaseManager.UpdateStreamPhase(ctx, definition, nil, nextPhase, eventFunc)
 
+}
+
+func (j *JobBackend) NoOp(ctx context.Context, definition Definition, backfillRequest *v1.BackfillRequest, nextPhase Phase, eventFunc controllers.EventFunc) (reconcile.Result, error) {
+	return j.phaseManager.UpdateStreamPhase(ctx, definition, backfillRequest, nextPhase, eventFunc)
 }
 
 func (j *JobBackend) startNewJob(ctx context.Context, definition Definition, request *v1.BackfillRequest, streamClass *v1.StreamClass) error {

--- a/services/controllers/stream/phase_manager.go
+++ b/services/controllers/stream/phase_manager.go
@@ -8,6 +8,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-type PhaseManager interface {
+type StatusManager interface {
 	UpdateStreamPhase(ctx context.Context, definition Definition, backfillRequest *v1.BackfillRequest, next Phase, eventFunc controllers.EventFunc) (reconcile.Result, error)
 }

--- a/services/controllers/stream/stream_reconciler.go
+++ b/services/controllers/stream/stream_reconciler.go
@@ -27,7 +27,6 @@ import (
 var (
 	_ reconcile.Reconciler            = (*streamReconciler)(nil)
 	_ controllers.UnmanagedReconciler = (*streamReconciler)(nil)
-	_ PhaseManager                    = (*streamReconciler)(nil)
 )
 
 type streamReconciler struct {
@@ -38,6 +37,7 @@ type streamReconciler struct {
 	eventRecorder          record.EventRecorder
 	definitionParser       DefinitionParser
 	backendResourceManager BackendResourceManager
+	phaseManager           StatusManager
 }
 
 func (s *streamReconciler) SetupUnmanaged(cache cache.Cache, scheme *runtime.Scheme, mapper meta.RESTMapper) (controller.Controller, error) {
@@ -48,7 +48,7 @@ func (s *streamReconciler) SetupUnmanaged(cache cache.Cache, scheme *runtime.Sch
 		return nil, fmt.Errorf("failed to start unmanaged stream controller: %w", err)
 	}
 
-	err = s.backendResourceManager.SetupWithController(cache, scheme, mapper, newController, s, s.gvk)
+	err = s.backendResourceManager.SetupWithController(cache, scheme, mapper, newController, s.gvk)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start backend resource watcher: %w", err)
 	}
@@ -83,18 +83,17 @@ func (s *streamReconciler) SetupUnmanaged(cache cache.Cache, scheme *runtime.Sch
 }
 
 // NewStreamReconciler creates a new StreamReconciler instance.
-func NewStreamReconciler(client client.Client, gvk schema.GroupVersionKind, jobBuilder JobBuilder, streamClass *v1.StreamClass, eventRecorder record.EventRecorder, definitionParser DefinitionParser) controllers.UnmanagedReconciler {
-	rec := &streamReconciler{
-		gvk:              gvk,
-		jobBuilder:       jobBuilder,
-		client:           client,
-		streamClass:      streamClass,
-		eventRecorder:    eventRecorder,
-		definitionParser: definitionParser,
+func NewStreamReconciler(client client.Client, gvk schema.GroupVersionKind, jobBuilder JobBuilder, streamClass *v1.StreamClass, eventRecorder record.EventRecorder, definitionParser DefinitionParser, phaseManager StatusManager, manager BackendResourceManager) controllers.UnmanagedReconciler {
+	return &streamReconciler{
+		gvk:                    gvk,
+		jobBuilder:             jobBuilder,
+		client:                 client,
+		streamClass:            streamClass,
+		eventRecorder:          eventRecorder,
+		definitionParser:       definitionParser,
+		backendResourceManager: manager,
+		phaseManager:           phaseManager,
 	}
-	backend := NewJobBackend(client, jobBuilder, eventRecorder, rec)
-	rec.backendResourceManager = backend
-	return rec
 }
 
 // Reconcile implements the reconciliation loop for Stream resources.
@@ -228,7 +227,7 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 		})
 
 	case phase == Suspended && backfillRequest != nil:
-		return s.UpdateStreamPhase(ctx, definition, backfillRequest, Pending, func() {
+		return s.backendResourceManager.NoOp(ctx, definition, backfillRequest, Pending, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),
 				"Normal",
 				"BackfillRequested",
@@ -244,7 +243,7 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 		})
 
 	case phase == Suspended && !definition.Suspended():
-		return s.UpdateStreamPhase(ctx, definition, backfillRequest, Pending, func() {
+		return s.backendResourceManager.NoOp(ctx, definition, backfillRequest, Pending, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),
 				"Normal",
 				"StreamResumed",
@@ -284,7 +283,7 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 		})
 
 	case phase == Backfilling && !job.IsCompleted():
-		return s.UpdateStreamPhase(ctx, definition, backfillRequest, Backfilling, func() {
+		return s.backendResourceManager.NoOp(ctx, definition, backfillRequest, Backfilling, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),
 				"Normal",
 				"BackfillInProgress",
@@ -322,7 +321,7 @@ func (s *streamReconciler) startBackfill(ctx context.Context, definition Definit
 		return reconcile.Result{}, err
 	}
 
-	return s.UpdateStreamPhase(ctx, definition, backfillRequest, nextPhase, eventFunc)
+	return s.phaseManager.UpdateStreamPhase(ctx, definition, backfillRequest, nextPhase, eventFunc)
 }
 
 func (s *streamReconciler) completeBackfill(ctx context.Context, job *StreamingJob, definition Definition, request *v1.BackfillRequest, nextStatus Phase, eventFunc controllers.EventFunc) (reconcile.Result, error) {
@@ -346,7 +345,7 @@ func (s *streamReconciler) completeBackfill(ctx context.Context, job *StreamingJ
 
 	}
 
-	return s.UpdateStreamPhase(ctx, definition, nil, nextStatus, eventFunc)
+	return s.phaseManager.UpdateStreamPhase(ctx, definition, nil, nextStatus, eventFunc)
 }
 
 func (s *streamReconciler) getBackfillRequest(ctx context.Context, definition Definition) (*v1.BackfillRequest, error) {
@@ -369,54 +368,4 @@ func (s *streamReconciler) getLogger(_ context.Context, request types.Namespaced
 	return klog.Background().
 		WithName("StreamReconciler").
 		WithValues("namespace", request.Namespace, "streamId", request.Name, "streamKind", s.gvk.Kind)
-}
-
-func (s *streamReconciler) UpdateStreamPhase(ctx context.Context, definition Definition, backfillRequest *v1.BackfillRequest, next Phase, eventFunc controllers.EventFunc) (reconcile.Result, error) {
-	logger := s.getLogger(ctx, definition.NamespacedName())
-
-	if definition.GetPhase() == next { // coverage-ignore
-		logger.V(1).Info("Stream phase is already set", "phase", definition.GetPhase())
-		return reconcile.Result{}, nil
-	}
-
-	logger.V(0).Info("updating Stream status", "from", definition.GetPhase(), "to", next)
-
-	// Refetch the definition to ensure we have the latest version before updating status
-	definition, err := GetStreamForClass(ctx, s.client, s.streamClass, definition.NamespacedName(), s.definitionParser)
-	if err != nil {
-		logger.V(0).Error(err, "unable to fetch Stream for status update")
-		return reconcile.Result{}, err
-	}
-	err = definition.SetPhase(next)
-	if err != nil { // coverage-ignore
-		logger.V(0).Error(err, "unable to set Stream status")
-		return reconcile.Result{}, err
-	}
-
-	err = definition.RecomputeConfiguration(backfillRequest)
-	if err != nil { // coverage-ignore
-		logger.V(0).Error(err, "unable to recompute Stream configuration hash")
-		return reconcile.Result{}, err
-	}
-
-	err = definition.SetConditions(definition.ComputeConditions(backfillRequest))
-
-	if err != nil { // coverage-ignore
-		logger.V(0).Error(err, "unable to set Stream conditions")
-		return reconcile.Result{}, err
-	}
-
-	statusUpdate := definition.ToUnstructured().DeepCopy()
-	err = s.client.Status().Update(ctx, statusUpdate)
-	if err != nil { // coverage-ignore
-		logger.V(1).Error(err, "unable to update Stream status")
-		return reconcile.Result{}, err
-	}
-
-	if eventFunc != nil {
-		eventFunc()
-	}
-
-	return reconcile.Result{}, nil
-
 }

--- a/services/controllers/stream/stream_reconciler_test.go
+++ b/services/controllers/stream/stream_reconciler_test.go
@@ -590,13 +590,16 @@ func createReconciler(k8sClient client.Client, mockJob *batchv1.Job, mockCtrl *g
 			PluralName:  "mockstreamdefinitions",
 		},
 	}
-	return NewStreamReconciler(k8sClient, gvk, jobBuilder, &sc, recorder, func(u *unstructured.Unstructured) (Definition, error) {
+	definitionParser := func(u *unstructured.Unstructured) (Definition, error) {
 		var mock testv1.MockStreamDefinition
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &mock); err != nil {
 			return nil, err
 		}
 		return NewMockDefinitionWrapper(&mock)
-	})
+	}
+	statusManager := NewDefaultStatusManager(k8sClient, gvk, &sc, definitionParser)
+	backendResourceManager := NewJobBackend(k8sClient, jobBuilder, recorder, statusManager)
+	return NewStreamReconciler(k8sClient, gvk, jobBuilder, &sc, recorder, definitionParser, statusManager, backendResourceManager)
 }
 
 // Helper function that combines multiple definition modifiers into one

--- a/services/stream_controller_factory.go
+++ b/services/stream_controller_factory.go
@@ -24,7 +24,9 @@ type streamControllerFactory struct {
 }
 
 func (s streamControllerFactory) CreateStreamController(_ context.Context, gvk schema.GroupVersionKind, streamClass *v1.StreamClass) (controller.Controller, error) { // coverage-ignore (trivial)
-	streamReconciler := stream.NewStreamReconciler(s.client, gvk, s.jobBuilder, streamClass, s.eventRecorder, s.definitionParser)
+	statusManager := stream.NewDefaultStatusManager(s.client, gvk, streamClass, s.definitionParser)
+	backend := stream.NewJobBackend(s.client, s.jobBuilder, s.eventRecorder, statusManager)
+	streamReconciler := stream.NewStreamReconciler(s.client, gvk, s.jobBuilder, streamClass, s.eventRecorder, s.definitionParser, statusManager, backend)
 	unmanaged, err := streamReconciler.SetupUnmanaged(s.manager.GetCache(), s.manager.GetScheme(), s.manager.GetRESTMapper())
 	return unmanaged, err
 }


### PR DESCRIPTION
Part of non-streaming YAMLs

## Scope

Implemented:
- This PR extracts status manager to a different class. It is needed since Status can be updated both from reconciler and backend, but we need to avoid chicken and egg problem.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.