### PR TITLE
Add backfill properties to the job

### DIFF
--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ mock-stream-plugin:
         --namespace default \
         --set jobTemplateSettings.podFailurePolicySettings.retryOnExitCodes="{120,121}" \
         --set jobTemplateSettings.backoffLimit=1 \
-        --version v1.0.7-13-g20d64ce
+        --version v1.0.8
 
 manifests:
     kubectl apply -f integration_tests/manifests/*.yaml

--- a/services/controllers/contracts/common/configurator_provider.go
+++ b/services/controllers/contracts/common/configurator_provider.go
@@ -21,13 +21,19 @@ func NewConfiguratorProvider(u *unstructured.Unstructured, parent stream.Definit
 }
 
 func (c *ConfiguratorProvider) JobConfigurator() (job.Configurator, error) { // coverage-ignore (should be tested in integration tests)
-	configurator := job.NewConfiguratorChainBuilder().
+	// For job streams this configurator always emit a non-backfill configurator
+	// which could be overridden by backfill request later in the reconciliation loop if BFR is provided.
+	// For cronjob streams this configurator always emit a backfill configurator since cronjob stream only supports
+	// backfill mode.
+	alwaysBackfill := c.parent.GetBackend() == stream.CronJob
+
+	configuratorBuilder := job.NewConfiguratorChainBuilder().
 		WithConfigurator(job.NewNameConfigurator(c.underlying.GetName())).
 		WithConfigurator(job.NewNamespaceConfigurator(c.underlying.GetNamespace())).
 		WithConfigurator(job.NewMetadataConfigurator(c.underlying.GetName(), c.underlying.GetKind())).
-		WithConfigurator(job.NewBackfillConfigurator(false)).
+		WithConfigurator(job.NewBackfillConfigurator(alwaysBackfill)).
 		WithConfigurator(job.NewEnvironmentConfigurator(c.underlying.Object["spec"], "SPEC")).
-		WithConfigurator(job.NewOwnerConfigurator(c.parent.ToOwnerReference())).
-		Build()
-	return configurator, nil
+		WithConfigurator(job.NewOwnerConfigurator(c.parent.ToOwnerReference()))
+
+	return configuratorBuilder.Build(), nil
 }


### PR DESCRIPTION
Fixes/Implements #<issue number>.

## Scope

Implemented:
- Fixed behavior when cron job starts regular streaming job instead of backfill

## Checklist

- [ ] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.