### PR TITLE
Make streamId a selectable field

### DIFF
--- a/pkg/apis/streaming/v1/types.go
+++ b/pkg/apis/streaming/v1/types.go
@@ -128,6 +128,7 @@ type BackfillRequestStatus struct {
 // +kubebuilder:printcolumn:name="StreamId",type=string,JSONPath=`.spec.streamId`
 // +kubebuilder:printcolumn:name="Completed",type=string,JSONPath=`.spec.completed`
 // +kubebuilder:selectablefield:JSONPath=.spec.completed
+// +kubebuilder:selectablefield:JSONPath=.spec.streamId
 type BackfillRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Part of the external triggering feature

## Scope

Implemented:
- The field `.spec.streamId` in the BackfillRequest is a selectable field now.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.