### PR TITLE
Implement the event for no valid backend

### DIFF
--- a/services/controllers/contracts/v1/execution_settings_wrapper.go
+++ b/services/controllers/contracts/v1/execution_settings_wrapper.go
@@ -151,7 +151,11 @@ func (e *ExecutionSettingsWrapper) GetBackend() stream.Backend {
 	if e.underlyingSpec.ExecutionSettings.StreamingBackend.CronJobBackend != nil {
 		return stream.CronJob
 	}
-	return stream.BatchJob
+	if e.underlyingSpec.ExecutionSettings.StreamingBackend.BatchJobBackend != nil {
+		return stream.BatchJob
+	}
+
+	return stream.NoBackend
 }
 
 func (e *ExecutionSettingsWrapper) GetPreviousBackend(ctx context.Context, c client.Client) (*stream.Backend, error) {

--- a/services/controllers/contracts/v1/execution_settings_wrapper_test.go
+++ b/services/controllers/contracts/v1/execution_settings_wrapper_test.go
@@ -335,7 +335,7 @@ func TestUnstructuredWrapper_GetBackend_Default(t *testing.T) {
 	backend := wrapper.GetBackend()
 
 	// Assert
-	require.Equal(t, stream.BatchJob, backend)
+	require.Equal(t, stream.NoBackend, backend)
 }
 
 func TestUnstructuredWrapper_GetBackend_BatchJob(t *testing.T) {

--- a/services/controllers/stream/backend/empty/backend.go
+++ b/services/controllers/stream/backend/empty/backend.go
@@ -11,7 +11,6 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -50,10 +49,4 @@ func (j *Backend) Remove(_ context.Context, _ stream.Definition, _ stream.Phase,
 func (j *Backend) NoOp(_ context.Context, _ stream.Definition, _ *v1.BackfillRequest, _ stream.Phase, eventFunc controllers.EventFunc) (reconcile.Result, error) {
 	eventFunc()
 	return reconcile.Result{}, nil
-}
-
-func (j *Backend) getLogger(_ context.Context, request types.NamespacedName) klog.Logger {
-	return klog.Background().
-		WithName("no_backend.Backend").
-		WithValues("namespace", request.Namespace, "streamId", request.Name)
 }

--- a/services/controllers/stream/backend/empty/backend.go
+++ b/services/controllers/stream/backend/empty/backend.go
@@ -28,25 +28,25 @@ func NewEmptyBackend(eventRecorder record.EventRecorder) *Backend {
 	}
 }
 
-func (j *Backend) SetupWithController(_ cache.Cache, _ *runtime.Scheme, _ meta.RESTMapper, _ controller.Controller, _ schema.GroupVersionKind) error {
+func (j *Backend) SetupWithController(_ cache.Cache, _ *runtime.Scheme, _ meta.RESTMapper, _ controller.Controller, _ schema.GroupVersionKind) error { // coverage-ignore (trivial)
 	return nil
 }
 
-func (j *Backend) Get(_ context.Context, _ types.NamespacedName) (stream.BackendResource, error) {
+func (j *Backend) Get(_ context.Context, _ types.NamespacedName) (stream.BackendResource, error) { // coverage-ignore (trivial)
 	return FromResource(nil)
 }
 
-func (j *Backend) Apply(_ context.Context, _ stream.Definition, _ *v1.BackfillRequest, _ stream.Phase, _ *v1.StreamClass, eventFunc controllers.EventFunc) (reconcile.Result, error) {
+func (j *Backend) Apply(_ context.Context, _ stream.Definition, _ *v1.BackfillRequest, _ stream.Phase, _ *v1.StreamClass, eventFunc controllers.EventFunc) (reconcile.Result, error) { // coverage-ignore (trivial)
 	eventFunc()
 	return reconcile.Result{}, nil
 }
 
-func (j *Backend) Remove(_ context.Context, _ stream.Definition, _ stream.Phase, eventFunc controllers.EventFunc) (reconcile.Result, error) {
+func (j *Backend) Remove(_ context.Context, _ stream.Definition, _ stream.Phase, eventFunc controllers.EventFunc) (reconcile.Result, error) { // coverage-ignore (trivial)
 	eventFunc()
 	return reconcile.Result{}, nil
 }
 
-func (j *Backend) NoOp(_ context.Context, _ stream.Definition, _ *v1.BackfillRequest, _ stream.Phase, eventFunc controllers.EventFunc) (reconcile.Result, error) {
+func (j *Backend) NoOp(_ context.Context, _ stream.Definition, _ *v1.BackfillRequest, _ stream.Phase, eventFunc controllers.EventFunc) (reconcile.Result, error) { // coverage-ignore (trivial)
 	eventFunc()
 	return reconcile.Result{}, nil
 }

--- a/services/controllers/stream/backend/empty/backend.go
+++ b/services/controllers/stream/backend/empty/backend.go
@@ -1,0 +1,59 @@
+package empty
+
+import (
+	"context"
+
+	v1 "github.com/SneaksAndData/arcane-operator/pkg/apis/streaming/v1"
+	"github.com/SneaksAndData/arcane-operator/services/controllers"
+	"github.com/SneaksAndData/arcane-operator/services/controllers/stream"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ stream.BackendResourceManager = (*Backend)(nil)
+
+type Backend struct {
+	eventRecorder record.EventRecorder
+}
+
+func NewEmptyBackend(eventRecorder record.EventRecorder) *Backend {
+	return &Backend{
+		eventRecorder: eventRecorder,
+	}
+}
+
+func (j *Backend) SetupWithController(_ cache.Cache, _ *runtime.Scheme, _ meta.RESTMapper, _ controller.Controller, _ schema.GroupVersionKind) error {
+	return nil
+}
+
+func (j *Backend) Get(_ context.Context, _ types.NamespacedName) (stream.BackendResource, error) {
+	return FromResource(nil)
+}
+
+func (j *Backend) Apply(_ context.Context, _ stream.Definition, _ *v1.BackfillRequest, _ stream.Phase, _ *v1.StreamClass, eventFunc controllers.EventFunc) (reconcile.Result, error) {
+	eventFunc()
+	return reconcile.Result{}, nil
+}
+
+func (j *Backend) Remove(_ context.Context, _ stream.Definition, _ stream.Phase, eventFunc controllers.EventFunc) (reconcile.Result, error) {
+	eventFunc()
+	return reconcile.Result{}, nil
+}
+
+func (j *Backend) NoOp(_ context.Context, _ stream.Definition, _ *v1.BackfillRequest, _ stream.Phase, eventFunc controllers.EventFunc) (reconcile.Result, error) {
+	eventFunc()
+	return reconcile.Result{}, nil
+}
+
+func (j *Backend) getLogger(_ context.Context, request types.NamespacedName) klog.Logger {
+	return klog.Background().
+		WithName("no_backend.Backend").
+		WithValues("namespace", request.Namespace, "streamId", request.Name)
+}

--- a/services/controllers/stream/backend/empty/backend_resource.go
+++ b/services/controllers/stream/backend/empty/backend_resource.go
@@ -1,0 +1,54 @@
+package empty
+
+import (
+	"fmt"
+
+	"github.com/SneaksAndData/arcane-operator/services/controllers/stream"
+	v1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ stream.BackendResource = (*BackendResource)(nil)
+
+type BackendResource struct {
+	*v1.Job
+}
+
+func (j *BackendResource) Name() string { // coverage-ignore (trivial)
+	return ""
+}
+
+func (j *BackendResource) UID() types.UID { // coverage-ignore (trivial)
+	return ""
+}
+
+func (j *BackendResource) CurrentConfiguration() (string, error) { // coverage-ignore (trivial)
+	return "", nil
+}
+
+func (j *BackendResource) IsCompleted() bool { // coverage-ignore (trivial)
+	return true
+}
+
+func (j *BackendResource) IsFailed() bool { // coverage-ignore (trivial)
+	return false
+}
+
+func (j *BackendResource) ToObject() client.Object { // coverage-ignore (trivial)
+	return j.Job
+}
+
+func (j *BackendResource) IsBackfill() bool { // coverage-ignore (trivial)
+	return false
+}
+
+func FromResource(job client.Object) (stream.BackendResource, error) { // coverage-ignore (trivial)
+	jobObj, isJob := job.(*v1.Job)
+
+	if !isJob {
+		return nil, fmt.Errorf("object is not a Job")
+	}
+
+	return &BackendResource{Job: jobObj}, nil
+}

--- a/services/controllers/stream/stream_definition.go
+++ b/services/controllers/stream/stream_definition.go
@@ -15,8 +15,9 @@ import (
 type Backend string
 
 const (
-	BatchJob Backend = "BatchJobBackend"
-	CronJob  Backend = "CronJob"
+	BatchJob  Backend = "BatchJobBackend"
+	CronJob   Backend = "CronJob"
+	NoBackend Backend = ""
 )
 
 type Phase string

--- a/services/controllers/stream/stream_reconciler.go
+++ b/services/controllers/stream/stream_reconciler.go
@@ -173,6 +173,14 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 				"The stream %s has failed", definition.NamespacedName().Name)
 		})
 
+	case phase == New && definition.GetBackend() == NoBackend:
+		return s.backendResourceManagers[definition.GetBackend()].NoOp(ctx, definition, nil, New, func() {
+			s.eventRecorder.Eventf(definition.ToUnstructured(),
+				"Warning",
+				"NoValidBackend",
+				"No valid streaming backend configured for %s", definition.NamespacedName().Name)
+		})
+
 	case phase == New && definition.Suspended():
 		return s.backendResourceManagers[definition.GetBackend()].Remove(ctx, definition, Suspended, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),

--- a/services/controllers/stream/tests/helpers/assertions.go
+++ b/services/controllers/stream/tests/helpers/assertions.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"testing"
+	"time"
 
 	v1 "github.com/SneaksAndData/arcane-operator/pkg/apis/streaming/v1"
 	testv2 "github.com/SneaksAndData/arcane-operator/pkg/test/apis_test/streaming/v2"
@@ -11,6 +12,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -73,4 +75,35 @@ func AssertBackfillRequestCompleted(t *testing.T, k8sClient client.Client, objec
 	err := k8sClient.Get(t.Context(), types.NamespacedName{Name: "backfill1", Namespace: objectName.Namespace}, backfillRequest)
 	require.NoError(t, err)
 	require.True(t, backfillRequest.Spec.Completed)
+}
+
+// AssertEventRecorded drains all events currently buffered in the FakeRecorder
+// and runs the provided assertion against each one. Each event has the format
+// "<type> <reason> <message>" as produced by record.FakeRecorder.
+// If additionalAssert is nil, only asserts that at least one event was recorded.
+func AssertEventRecorded(t *testing.T, recorder *record.FakeRecorder, _ types.NamespacedName, additionalAssert func(*testing.T, string)) {
+	t.Helper()
+	events := drainEvents(recorder)
+	require.NotEmpty(t, events, "expected at least one event to be recorded")
+	if additionalAssert == nil {
+		return
+	}
+	for _, ev := range events {
+		additionalAssert(t, ev)
+	}
+}
+
+func drainEvents(recorder *record.FakeRecorder) []string {
+	var out []string
+	for {
+		select {
+		case ev, ok := <-recorder.Events:
+			if !ok {
+				return out
+			}
+			out = append(out, ev)
+		case <-time.After(10 * time.Millisecond):
+			return out
+		}
+	}
 }

--- a/services/controllers/stream/tests/helpers/v2/mock_stream_definition_builder.go
+++ b/services/controllers/stream/tests/helpers/v2/mock_stream_definition_builder.go
@@ -74,6 +74,14 @@ func (b *MockStreamDefinitionBuilder) WithSchedule(schedule string) *MockStreamD
 	return b
 }
 
+// WithNoBackend configures the stream definition with an empty backend,
+// clearing both the batch job and cron job backends.
+func (b *MockStreamDefinitionBuilder) WithNoBackend() *MockStreamDefinitionBuilder {
+	b.definition.Spec.ExecutionSettings.StreamingBackend.BatchJobBackend = nil
+	b.definition.Spec.ExecutionSettings.StreamingBackend.CronJobBackend = nil
+	return b
+}
+
 // Apply runs an arbitrary mutation function on the underlying definition.
 // This allows composing the builder with the existing functional-option style
 // helpers in this package.

--- a/services/controllers/stream/tests/v1/stream_reconciler_test.go
+++ b/services/controllers/stream/tests/v1/stream_reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/SneaksAndData/arcane-operator/services/controllers/contracts"
 	"github.com/SneaksAndData/arcane-operator/services/controllers/stream"
 	"github.com/SneaksAndData/arcane-operator/services/controllers/stream/backend/cron_job"
+	"github.com/SneaksAndData/arcane-operator/services/controllers/stream/backend/empty"
 	"github.com/SneaksAndData/arcane-operator/services/controllers/stream/backend/job"
 	"github.com/SneaksAndData/arcane-operator/services/controllers/stream/tests/helpers"
 	v3 "github.com/SneaksAndData/arcane-operator/services/controllers/stream/tests/helpers/v2"
@@ -29,7 +30,7 @@ var objectName = types.NamespacedName{Name: "stream1", Namespace: "default"}
 func Test_UpdatePhase_New_To_Suspended(t *testing.T) {
 	// Arrange
 	k8sClient := helpers.SetupClientFromBuilders(nil, v3.NewMockStreamDefinitionBuilder(objectName), nil)
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -45,7 +46,7 @@ func Test_UpdatePhase_New_To_Pending(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -62,7 +63,7 @@ func Test_UpdatePhase_New_To_Pending_with_schedule(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithSuspendedSpec(false).WithSchedule("* * * * *")
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -74,6 +75,27 @@ func Test_UpdatePhase_New_To_Pending_with_schedule(t *testing.T) {
 	helpers.AssertJobNotExists(t, k8sClient, objectName)
 }
 
+func Test_UpdatePhase_New_To_Pending_with_no_backend(t *testing.T) {
+	// Arrange
+	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithSuspendedSpec(false).WithNoBackend()
+
+	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
+
+	reconciler, recorder := createReconciler(k8sClient, nil, nil)
+
+	// Act
+	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
+	require.NoError(t, err)
+	require.Equal(t, result, reconcile.Result{})
+
+	// Assert
+	helpers.AssertStreamDefinitionPhase(t, k8sClient, objectName, stream.New)
+	helpers.AssertEventRecorded(t, recorder, objectName, func(t *testing.T, event string) {
+		require.Contains(t, event, "Warning NoValidBackend")
+	})
+	helpers.AssertJobNotExists(t, k8sClient, objectName)
+}
+
 func Test_UpdatePhase_Pending_To_Running_no_job(t *testing.T) {
 	// Arrange
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithSuspendedSpec(false).WithPhase(stream.Pending)
@@ -82,7 +104,7 @@ func Test_UpdatePhase_Pending_To_Running_no_job(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -113,7 +135,7 @@ func Test_UpdatePhase_Pending_To_Running_recreate_job(t *testing.T) {
 		},
 	}
 
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -146,7 +168,7 @@ func Test_UpdatePhase_Pending_To_Running_not_recreate_job(t *testing.T) {
 	// Create the fake client and resources
 	resources := helpers.NewFakeClientResourcesBuilder().WithConsistentJob(objectName, definitionHash)
 	k8sClient = helpers.SetupClientFromBuilders(nil, streamDefinitionBuilder, resources)
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -168,7 +190,7 @@ func Test_UpdatePhase_Pending_To_Scheduled_no_job(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -193,7 +215,7 @@ func Test_UpdatePhase_Pending_To_Backfilling_no_job(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -222,7 +244,7 @@ func Test_UpdatePhase_Pending_To_Backfilling_recreate_job(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -240,7 +262,7 @@ func Test_UpdatePhase_Running_To_Suspended_no_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Running).WithSuspendedSpec(true)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -256,7 +278,7 @@ func Test_UpdatePhase_Running_To_Suspended_stop_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Running).WithSuspendedSpec(true)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName).WithOutdatedJob(objectName))
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -273,7 +295,7 @@ func Test_UpdatePhase_Running_To_Suspended_to_Pending(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -289,7 +311,7 @@ func Test_UpdatePhase_Running_To_Suspended_to_Pending_With_BFR(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended).WithSuspendedSpec(true)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -305,7 +327,7 @@ func Test_UpdatePhase_Running_To_Pending_with_schedule(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Running).WithSuspendedSpec(false).WithSchedule("* * * * *")
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithOutdatedJob(objectName))
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -322,7 +344,7 @@ func Test_UpdatePhase_Running_with_BackfillRequest_no_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Running).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -338,7 +360,7 @@ func Test_UpdatePhase_Suspended_with_BackfillRequest(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -354,7 +376,7 @@ func Test_UpdatePhase_Suspended_without_BackfillRequest_without_job(t *testing.T
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -371,7 +393,7 @@ func Test_UpdatePhase_Suspended_without_BackfillRequest_with_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithOutdatedJob(objectName))
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -388,7 +410,7 @@ func Test_UpdatePhase_Backfilling_To_Pending_with_job_completed(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName).WithCompletedJob(objectName))
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -406,7 +428,7 @@ func Test_UpdatePhase_Backfilling_To_Pending_with_deleted_bfr(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithOutdatedJob(objectName))
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	helpers.AssertJobExists(t, k8sClient, objectName)
 
@@ -425,7 +447,7 @@ func Test_UpdatePhase_Backfilling_To_Backfilling_with_job_running(t *testing.T) 
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithOutdatedJob(objectName).WithBackfillRequest(objectName))
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -455,7 +477,7 @@ func Test_UpdatePhase_Backfilling_To_Backfilling_with_no_job(t *testing.T) {
 			},
 		},
 	}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -485,7 +507,7 @@ func Test_UpdatePhase_Pending_To_Backfilling_with_schedule(t *testing.T) {
 			},
 		},
 	}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -503,7 +525,7 @@ func Test_UpdatePhase_Backfilling_To_Pending_with_schedule(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(false).WithSchedule("* * * * *")
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithOutdatedJob(objectName))
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -532,7 +554,7 @@ func Test_UpdatePhase_Backfilling_To_Suspended(t *testing.T) {
 			},
 		},
 	}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -549,7 +571,7 @@ func Test_UpdatePhase_Backfilling_Job_Failed(t *testing.T) {
 	// Arrange
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName).WithFailedJob(objectName))
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -571,7 +593,7 @@ func Test_UpdatePhase_Backfilling_To_Running(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Namespace: objectName.Namespace, Name: objectName.Name}}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -588,7 +610,7 @@ func Test_UpdatePhase_Failed_to_Failed(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Failed)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithFailedJob(objectName))
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -605,7 +627,7 @@ func Test_UpdatePhase_Failed_to_Failed_without_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Failed).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -621,7 +643,7 @@ func Test_UpdatePhase_Failed_to_Suspended_without_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Failed).WithSuspendedSpec(true)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -637,7 +659,7 @@ func Test_UpdatePhase_Failed_to_Suspended_with_BackfillRequest(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Failed).WithSuspendedSpec(true)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -657,7 +679,7 @@ func Test_UpdatePhase_Failed_to_Backfilling(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -689,7 +711,7 @@ func Test_UpdatePhase_Scheduled_to_Scheduled_no_cron_job(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -729,7 +751,7 @@ func Test_UpdatePhase_Scheduled_to_Scheduled_recreate_cron_job(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -772,7 +794,7 @@ func Test_UpdatePhase_Scheduled_to_Scheduled_not_recreate_cron_job(t *testing.T)
 	err = k8sClient.Get(t.Context(), objectName, oldJob)
 	require.NoError(t, err)
 
-	reconciler := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -798,7 +820,7 @@ func Test_UpdatePhase_Scheduled_to_Suspended(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -818,7 +840,7 @@ func Test_UpdatePhase_Scheduled_to_Backfilling(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -831,7 +853,7 @@ func Test_UpdatePhase_Scheduled_to_Backfilling(t *testing.T) {
 	helpers.AssertBackfillRequestNotCompleted(t, k8sClient, objectName)
 }
 
-func createReconciler(k8sClient client.Client, mockJob *batchv1.Job, mockCtrl *gomock.Controller) reconcile.Reconciler {
+func createReconciler(k8sClient client.Client, mockJob *batchv1.Job, mockCtrl *gomock.Controller) (reconcile.Reconciler, *record.FakeRecorder) {
 	var jobBuilder *mocks.MockJobBuilder
 	if mockJob != nil {
 		jobBuilder = mocks.NewMockJobBuilder(mockCtrl)
@@ -852,8 +874,17 @@ func createReconciler(k8sClient client.Client, mockJob *batchv1.Job, mockCtrl *g
 	statusManager := stream.NewDefaultStatusManager(k8sClient, gvk, &sc, contracts.FromUnstructured)
 	backfillBackendResourceManager := job.NewBackfillBackendResourceManager(&sc, k8sClient, statusManager, recorder)
 	backendResourceManagers := map[stream.Backend]stream.BackendResourceManager{
-		stream.BatchJob: job.NewJobBackend(k8sClient, jobBuilder, recorder, statusManager),
-		stream.CronJob:  cron_job.NewCronJobBackend(k8sClient, jobBuilder, recorder, statusManager),
+		stream.BatchJob:  job.NewJobBackend(k8sClient, jobBuilder, recorder, statusManager),
+		stream.CronJob:   cron_job.NewCronJobBackend(k8sClient, jobBuilder, recorder, statusManager),
+		stream.NoBackend: empty.NewEmptyBackend(recorder),
 	}
-	return stream.NewStreamReconciler(k8sClient, gvk, jobBuilder, &sc, recorder, contracts.FromUnstructured, backendResourceManagers, backfillBackendResourceManager)
+	reconciler := stream.NewStreamReconciler(k8sClient,
+		gvk,
+		jobBuilder,
+		&sc,
+		recorder,
+		contracts.FromUnstructured,
+		backendResourceManagers,
+		backfillBackendResourceManager)
+	return reconciler, recorder
 }

--- a/services/stream_controller_factory.go
+++ b/services/stream_controller_factory.go
@@ -6,6 +6,7 @@ import (
 	v1 "github.com/SneaksAndData/arcane-operator/pkg/apis/streaming/v1"
 	"github.com/SneaksAndData/arcane-operator/services/controllers/stream"
 	"github.com/SneaksAndData/arcane-operator/services/controllers/stream/backend/cron_job"
+	"github.com/SneaksAndData/arcane-operator/services/controllers/stream/backend/empty"
 	"github.com/SneaksAndData/arcane-operator/services/controllers/stream/backend/job"
 	"github.com/SneaksAndData/arcane-operator/services/controllers/stream_class"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,8 +30,9 @@ func (s streamControllerFactory) CreateStreamController(_ context.Context, gvk s
 	statusManager := stream.NewDefaultStatusManager(s.client, gvk, streamClass, s.definitionParser)
 	backfillBackend := job.NewBackfillBackendResourceManager(streamClass, s.client, statusManager, s.eventRecorder)
 	backends := map[stream.Backend]stream.BackendResourceManager{
-		stream.BatchJob: job.NewJobBackend(s.client, s.jobBuilder, s.eventRecorder, statusManager),
-		stream.CronJob:  cron_job.NewCronJobBackend(s.client, s.jobBuilder, s.eventRecorder, statusManager),
+		stream.BatchJob:  job.NewJobBackend(s.client, s.jobBuilder, s.eventRecorder, statusManager),
+		stream.CronJob:   cron_job.NewCronJobBackend(s.client, s.jobBuilder, s.eventRecorder, statusManager),
+		stream.NoBackend: empty.NewEmptyBackend(s.eventRecorder),
 	}
 	streamReconciler := stream.NewStreamReconciler(s.client, gvk, s.jobBuilder, streamClass, s.eventRecorder, s.definitionParser, backends, backfillBackend)
 	unmanaged, err := streamReconciler.SetupUnmanaged(s.manager.GetCache(), s.manager.GetScheme(), s.manager.GetRESTMapper())


### PR DESCRIPTION
Part of non-streaming YAMLs

## Scope

Implemented:
- Implemented the ability to emit an event if the backend is not properly configured.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.