### PR TITLE
Fix the Backfill stream context field

### DIFF
--- a/pkg/apis/streaming/v1/extensions.go
+++ b/pkg/apis/streaming/v1/extensions.go
@@ -58,7 +58,9 @@ var _ job.ConfiguratorProvider = (*BackfillRequest)(nil)
 // JobConfigurator returns a JobConfigurator for the BackfillRequest
 func (in *BackfillRequest) JobConfigurator() (job.Configurator, error) {
 	if in == nil {
-		return nil, nil
+		return job.NewConfiguratorChainBuilder().
+			WithConfigurator(job.NewBackfillConfigurator(false)).
+			Build(), nil
 	}
 	configurator := job.NewConfiguratorChainBuilder().
 		WithConfigurator(job.NewEnvironmentConfigurator(in.Spec, "OVERRIDE")).

--- a/tests/api_v0_test.go
+++ b/tests/api_v0_test.go
@@ -132,12 +132,20 @@ func Test_StaticBackfillId(t *testing.T) {
 			require.True(t, ok, "Expected a Job resource for a job")
 			envVars := job.ToObject().(*batchv1.Job).Spec.Template.Spec.Containers[0].Env
 			var backfillId string
+			var backfillValue string
 			for _, envVar := range envVars {
 				if envVar.Name == "STREAMCONTEXT__BACKFILL_ID" {
 					backfillId = envVar.Value
-					break
+				}
+				if envVar.Name == "STREAMCONTEXT__BACKFILL" {
+					backfillValue = envVar.Value
 				}
 			}
+
+			require.Contains(t,
+				[]string{"true", "false"},
+				backfillValue,
+				"Expected STREAMCONTEXT__BACKFILL to be 'true' or 'false'")
 
 			if job.IsBackfill() {
 				foundBackfillId = true

--- a/tests/api_v0_test.go
+++ b/tests/api_v0_test.go
@@ -142,10 +142,11 @@ func Test_StaticBackfillId(t *testing.T) {
 				}
 			}
 
-			require.Contains(t,
-				[]string{"true", "false"},
-				backfillValue,
-				"Expected STREAMCONTEXT__BACKFILL to be 'true' or 'false'")
+			if job.IsBackfill() {
+				require.Equal(t, "true", backfillValue, "Backfill job should have STREAMCONTEXT__BACKFILL environment variable set to 'true'")
+			} else {
+				require.Equal(t, "false", backfillValue, "Streaming job should have STREAMCONTEXT__BACKFILL environment variable set to 'false'")
+			}
 
 			if job.IsBackfill() {
 				foundBackfillId = true

--- a/tests/api_v0_test.go
+++ b/tests/api_v0_test.go
@@ -18,6 +18,7 @@ import (
 // It watches for Job events in the Kubernetes cluster and checks that at least one backfill job and one regular job are created and completed.
 func Test_CreateStream(t *testing.T) {
 	// Arrange
+	t.Parallel()
 
 	// Act
 	name := createTestStreamDefinition(t, false)
@@ -59,6 +60,7 @@ func Test_CreateStream(t *testing.T) {
 // It watches for Job events in the Kubernetes cluster and checks that at least one backfill job and one regular job are created and completed.
 func Test_CreateFailedStream(t *testing.T) {
 	// Arrange
+	t.Parallel()
 
 	// Act
 	name := createTestStreamDefinition(t, true)
@@ -120,6 +122,7 @@ func Test_CreateFailedStream(t *testing.T) {
 func Test_StaticBackfillId(t *testing.T) {
 	// Arrange
 	var foundBackfillId bool
+	t.Parallel()
 
 	// Act
 	name := createTestStreamDefinition(t, false)

--- a/tests/api_v1_test.go
+++ b/tests/api_v1_test.go
@@ -183,12 +183,6 @@ func Test_DynamicBackfillId(t *testing.T) {
 			envVars := job.ToObject().(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env
 			var backfillId string
 			for _, envVar := range envVars {
-				if envVar.Name == "STREAMCONTEXT__BACKFILL" {
-					require.Contains(t,
-						[]string{"true", "false"},
-						envVar.Value,
-						"Expected STREAMCONTEXT__BACKFILL to be 'true' or 'false'")
-				}
 				if envVar.Name == "STREAMCONTEXT__BACKFILL_ID" {
 					backfillId = envVar.ValueFrom.FieldRef.FieldPath
 					// The value should be set from the job's metadata.labels['job-name']

--- a/tests/api_v1_test.go
+++ b/tests/api_v1_test.go
@@ -183,13 +183,18 @@ func Test_DynamicBackfillId(t *testing.T) {
 			envVars := job.ToObject().(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env
 			var backfillId string
 			for _, envVar := range envVars {
+				if envVar.Name == "STREAMCONTEXT__BACKFILL" {
+					require.Contains(t,
+						[]string{"true", "false"},
+						envVar.Value,
+						"Expected STREAMCONTEXT__BACKFILL to be 'true' or 'false'")
+				}
 				if envVar.Name == "STREAMCONTEXT__BACKFILL_ID" {
 					backfillId = envVar.ValueFrom.FieldRef.FieldPath
 					// The value should be set from the job's metadata.labels['job-name']
 					require.Equal(t, "metadata.labels['job-name']", backfillId,
 						"Expected STREAMCONTEXT__BACKFILL_ID to be sourced from job labels")
 					foundBackfillId = true
-					break
 				}
 			}
 		},


### PR DESCRIPTION
Fixes #294 

## Scope

Implemented:
- Fix the invalid behavior when the `STREAMCONTEXT__BACKFILL` environment variable is not provided by the operator.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.