### PR TITLE
Increase logging

### DIFF
--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ mock-stream-plugin:
         --namespace default \
         --set jobTemplateSettings.podFailurePolicySettings.retryOnExitCodes="{120,121}" \
         --set jobTemplateSettings.backoffLimit=1 \
-        --version v1.0.12
+        --version v1.0.12-2-g8536243
 
 manifests:
     kubectl apply -f integration_tests/manifests/*.yaml

--- a/services/controllers/stream/backend/cron_job/backend.go
+++ b/services/controllers/stream/backend/cron_job/backend.go
@@ -90,8 +90,10 @@ func (c *Backend) Apply(ctx context.Context, definition stream.Definition, backf
 		},
 	}
 
+	logger.V(0).Info("Creating the cron job for the stream definition")
 	err := c.client.Get(ctx, types.NamespacedName{Name: object.Name, Namespace: object.Namespace}, object)
 	if client.IgnoreNotFound(err) != nil {
+		logger.V(0).Error(err, "failed to fetch cronjob")
 		return reconcile.Result{}, fmt.Errorf("failed to fetch cronjob: %w", err)
 	}
 
@@ -102,7 +104,7 @@ func (c *Backend) Apply(ctx context.Context, definition stream.Definition, backf
 		}
 
 		if equals {
-			logger.V(1).Info("The job already exists with matching configuration, skipping creation")
+			logger.V(0).Info("The job already exists with matching configuration, skipping creation")
 			return c.statusManager.UpdateStreamPhase(ctx, definition, &v1.BackfillRequest{}, nextPhase, eventFunc)
 		}
 
@@ -114,16 +116,19 @@ func (c *Backend) Apply(ctx context.Context, definition stream.Definition, backf
 
 	j, err := c.BuildJob(ctx, definition, backfillRequest, streamClass)
 	if err != nil {
+		logger.V(0).Error(err, "failed to build job for cronjob backend")
 		return reconcile.Result{}, fmt.Errorf("failed to build job for cronjob backend: %w", err)
 	}
 
 	schedule, err := definition.GetSchedule()
 	if err != nil {
+		logger.V(0).Error(err, "failed to get schedule from stream definition")
 		return reconcile.Result{}, fmt.Errorf("failed to get schedule from stream definition: %w", err)
 	}
 
 	configuration, err := definition.CurrentConfiguration(backfillRequest)
 	if err != nil {
+		logger.V(0).Error(err, "failed to compute stream configuration hash")
 		return reconcile.Result{}, fmt.Errorf("failed to compute stream configuration hash: %w", err)
 	}
 
@@ -144,6 +149,7 @@ func (c *Backend) Apply(ctx context.Context, definition stream.Definition, backf
 
 	err = c.client.Create(ctx, object)
 	if err != nil {
+		logger.V(0).Error(err, "failed to create cron job")
 		return reconcile.Result{}, fmt.Errorf("failed to create cron job: %w", err)
 	}
 

--- a/services/controllers/stream/backend/cron_job/backend.go
+++ b/services/controllers/stream/backend/cron_job/backend.go
@@ -114,7 +114,9 @@ func (c *Backend) Apply(ctx context.Context, definition stream.Definition, backf
 		}
 	}
 
-	j, err := c.BuildJob(ctx, definition, backfillRequest, streamClass)
+	// Temporary add fake backfill request to the job builder since we need to create a CronJob with
+	// STREAMCONTEXT__BACKFILL == "true". Should be removed in the next PRs.
+	j, err := c.BuildJob(ctx, definition, &v1.BackfillRequest{}, streamClass)
 	if err != nil {
 		logger.V(0).Error(err, "failed to build job for cronjob backend")
 		return reconcile.Result{}, fmt.Errorf("failed to build job for cronjob backend: %w", err)

--- a/services/controllers/stream/stream_reconciler.go
+++ b/services/controllers/stream/stream_reconciler.go
@@ -86,7 +86,7 @@ func NewStreamReconciler(client client.Client, gvk schema.GroupVersionKind, jobB
 // Reconcile implements the reconciliation loop for Stream resources.
 func (s *streamReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 
-	logger := klog.FromContext(ctx).
+	logger := klog.Background().
 		WithValues("stream", request.NamespacedName).
 		WithValues("namespace", request.Namespace).
 		WithValues("streamId", request.Name, "streamKind", s.streamClass.Spec.KindRef)
@@ -126,7 +126,7 @@ func (s *streamReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 }
 
 func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, job BackendResource, backfillRequest *v1.BackfillRequest) (reconcile.Result, error) {
-	logger := klog.FromContext(ctx).
+	logger := klog.Background().
 		WithValues("namespace", definition.NamespacedName().Namespace).
 		WithValues("streamId", definition.NamespacedName().Name, "streamKind", s.streamClass.Spec.KindRef)
 
@@ -371,7 +371,7 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 }
 
 func tryTransitionBackend(ctx context.Context, s *streamReconciler, definition Definition, backfillRequest *v1.BackfillRequest) (bool, reconcile.Result, error) {
-	logger := klog.FromContext(ctx).
+	logger := klog.Background().
 		WithValues("namespace", definition.NamespacedName().Namespace).
 		WithValues("streamId", definition.NamespacedName().Name, "streamKind", s.streamClass.Spec.KindRef)
 	logger.V(0).Info("Trying to transit backend", "backend", definition.GetBackend())
@@ -402,7 +402,7 @@ func tryTransitionBackend(ctx context.Context, s *streamReconciler, definition D
 }
 
 func (s *streamReconciler) transitBackend(ctx context.Context, definition Definition, backfillRequest *v1.BackfillRequest) (reconcile.Result, error) {
-	logger := klog.FromContext(ctx).
+	logger := klog.Background().
 		WithValues("namespace", definition.NamespacedName().Namespace).
 		WithValues("streamId", definition.NamespacedName().Name, "streamKind", s.streamClass.Spec.KindRef)
 	logger.V(0).Info("Transiting the backend", "backend", definition.GetBackend())

--- a/services/controllers/stream/stream_reconciler.go
+++ b/services/controllers/stream/stream_reconciler.go
@@ -120,6 +120,11 @@ func (s *streamReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 	result, err := s.moveFsm(ctx, streamDefinition, backendResource, backfillRequest)
 	if err != nil {
+		s.eventRecorder.Eventf(
+			streamDefinition.ToUnstructured(),
+			"Warning",
+			"StreamSuspended",
+			"Failed to reconcile the stream: %v", err)
 		logger.V(0).Error(err, "Failed to move FSM for the stream")
 	}
 	return result, err
@@ -201,13 +206,15 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 
 	case phase == New && !definition.Suspended():
 		logger.V(0).Info("Transition to Pending")
-		return s.backfillBackendResourceManager.Apply(ctx, definition, s.newBackfillRequest(definition), Pending, s.streamClass, func() {
-			s.eventRecorder.Eventf(definition.ToUnstructured(),
-				"Normal",
-				"StreamCreated",
-				"Backfill was requested for the new stream definition: %s", definition.NamespacedName().Name)
-		})
-
+		if definition.GetBackend() == BatchJob {
+			return s.backfillBackendResourceManager.Apply(ctx, definition, s.newBackfillRequest(definition), Pending, s.streamClass, func() {
+				s.eventRecorder.Eventf(definition.ToUnstructured(),
+					"Normal",
+					"StreamCreated",
+					"Backfill was requested for the new stream definition: %s", definition.NamespacedName().Name)
+			})
+		}
+		return s.backendResourceManagers[definition.GetBackend()].NoOp(ctx, definition, nil, Pending, func() {})
 	case phase == Pending && backfillRequest == nil:
 		nextPhase := Running
 		logger.V(0).Info("Switching to the new backend", "backend", definition.GetBackend())

--- a/services/controllers/stream/stream_reconciler.go
+++ b/services/controllers/stream/stream_reconciler.go
@@ -113,7 +113,7 @@ func (s *streamReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	backendResource, err := s.backendResourceManagers[BatchJob].Get(ctx, request.NamespacedName)
-	if err != nil { // coverage-ignore
+	if client.IgnoreNotFound(err) != nil { // coverage-ignore
 		logger.V(0).Error(err, "Unable to fetch backend resource for the stream")
 		return reconcile.Result{}, err
 	}

--- a/services/controllers/stream/stream_reconciler.go
+++ b/services/controllers/stream/stream_reconciler.go
@@ -178,6 +178,7 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 		})
 
 	case phase == New && definition.GetBackend() == NoBackend:
+		logger.V(0).Info("Backend unknown")
 		return s.backendResourceManagers[definition.GetBackend()].NoOp(ctx, definition, nil, New, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),
 				"Warning",
@@ -186,6 +187,7 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 		})
 
 	case phase == New && definition.Suspended():
+		logger.V(0).Info("Transition to suspended")
 		return s.backendResourceManagers[definition.GetBackend()].Remove(ctx, definition, Suspended, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),
 				"Normal",
@@ -194,6 +196,7 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 		})
 
 	case phase == New && !definition.Suspended():
+		logger.V(0).Info("Transition to Pending")
 		return s.backfillBackendResourceManager.Apply(ctx, definition, s.newBackfillRequest(definition), Pending, s.streamClass, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),
 				"Normal",
@@ -210,6 +213,7 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 		return s.backendResourceManagers[definition.GetBackend()].Apply(ctx, definition, nil, nextPhase, s.streamClass, nil)
 
 	case phase == Pending && backfillRequest != nil:
+		logger.V(0).Info("Starting the backfill", "backend", definition.GetBackend())
 		return s.backendResourceManagers[BatchJob].Apply(ctx, definition, backfillRequest, Backfilling, s.streamClass, nil)
 
 	case phase == Running && definition.Suspended():
@@ -363,8 +367,14 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 }
 
 func tryTransitionBackend(ctx context.Context, s *streamReconciler, definition Definition, backfillRequest *v1.BackfillRequest) (bool, reconcile.Result, error) {
+	logger := klog.FromContext(ctx).
+		WithValues("namespace", definition.NamespacedName().Namespace).
+		WithValues("streamId", definition.NamespacedName().Name, "streamKind", s.streamClass.Spec.KindRef)
+	logger.V(0).Info("Trying to transit backend", "backend", definition.GetBackend())
+
 	backend, err := definition.GetPreviousBackend(ctx, s.client)
 	if err != nil {
+		logger.V(0).Error(err, "Failed to transit backend", "backend", definition.GetBackend())
 		return false, reconcile.Result{}, fmt.Errorf("failed to get previous backend for stream %s/%s: %w",
 			definition.NamespacedName().Namespace,
 			definition.NamespacedName().Name,
@@ -377,6 +387,7 @@ func tryTransitionBackend(ctx context.Context, s *streamReconciler, definition D
 
 	result, err := s.transitBackend(ctx, definition, backfillRequest)
 	if err != nil {
+		logger.V(0).Error(err, "Failed to transit backend", "backend", definition.GetBackend())
 		return false, result, fmt.Errorf("failed to transit backend for stream %s/%s: %w",
 			definition.NamespacedName().Namespace,
 			definition.NamespacedName().Name,
@@ -387,6 +398,11 @@ func tryTransitionBackend(ctx context.Context, s *streamReconciler, definition D
 }
 
 func (s *streamReconciler) transitBackend(ctx context.Context, definition Definition, backfillRequest *v1.BackfillRequest) (reconcile.Result, error) {
+	logger := klog.FromContext(ctx).
+		WithValues("namespace", definition.NamespacedName().Namespace).
+		WithValues("streamId", definition.NamespacedName().Name, "streamKind", s.streamClass.Spec.KindRef)
+	logger.V(0).Info("Transiting the backend", "backend", definition.GetBackend())
+
 	var eventFunc controllers.EventFunc
 	switch definition.GetBackend() {
 	case BatchJob:

--- a/services/controllers/stream/stream_reconciler.go
+++ b/services/controllers/stream/stream_reconciler.go
@@ -122,6 +122,10 @@ func (s *streamReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 }
 
 func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, job BackendResource, backfillRequest *v1.BackfillRequest) (reconcile.Result, error) {
+	logger := klog.FromContext(ctx).
+		WithValues("namespace", definition.NamespacedName().Namespace).
+		WithValues("streamId", definition.NamespacedName().Name, "streamKind", s.streamClass.Spec.KindRef)
+
 	phase := definition.GetPhase()
 
 	switch {
@@ -199,6 +203,7 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 
 	case phase == Pending && backfillRequest == nil:
 		nextPhase := Running
+		logger.V(0).Info("Switching to the new backend", "backend", definition.GetBackend())
 		if definition.GetBackend() == CronJob {
 			nextPhase = Scheduled
 		}
@@ -310,6 +315,7 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 		})
 
 	case phase == Running && definition.GetBackend() != BatchJob:
+		logger.V(0).Info("Switching backend for the stream without backfill")
 		return s.backendResourceManagers[definition.GetBackend()].Remove(ctx, definition, Pending, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),
 				"Normal",

--- a/services/controllers/stream/stream_reconciler.go
+++ b/services/controllers/stream/stream_reconciler.go
@@ -118,7 +118,11 @@ func (s *streamReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 		return reconcile.Result{}, err
 	}
 
-	return s.moveFsm(ctx, streamDefinition, backendResource, backfillRequest)
+	result, err := s.moveFsm(ctx, streamDefinition, backendResource, backfillRequest)
+	if err != nil {
+		logger.V(0).Error(err, "Failed to move FSM for the stream")
+	}
+	return result, err
 }
 
 func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, job BackendResource, backfillRequest *v1.BackfillRequest) (reconcile.Result, error) {

--- a/services/controllers/stream/tests/helpers/assertions.go
+++ b/services/controllers/stream/tests/helpers/assertions.go
@@ -77,6 +77,12 @@ func AssertBackfillRequestCompleted(t *testing.T, k8sClient client.Client, objec
 	require.True(t, backfillRequest.Spec.Completed)
 }
 
+func AssertBackfillRequests(t *testing.T, k8sClient client.Client, verify func(request *v1.BackfillRequestList, err error)) {
+	backfillRequestList := &v1.BackfillRequestList{}
+	err := k8sClient.List(t.Context(), backfillRequestList)
+	verify(backfillRequestList, err)
+}
+
 // AssertEventRecorded drains all events currently buffered in the FakeRecorder
 // and runs the provided assertion against each one. Each event has the format
 // "<type> <reason> <message>" as produced by record.FakeRecorder.

--- a/services/controllers/stream/tests/v1/stream_reconciler_test.go
+++ b/services/controllers/stream/tests/v1/stream_reconciler_test.go
@@ -71,6 +71,9 @@ func Test_UpdatePhase_New_To_Pending_with_schedule(t *testing.T) {
 	require.Equal(t, result, reconcile.Result{})
 
 	// Assert
+	helpers.AssertBackfillRequests(t, k8sClient, func(bfrList *v1.BackfillRequestList, err error) {
+		require.Equal(t, 0, len(bfrList.Items))
+	})
 	helpers.AssertStreamDefinitionPhase(t, k8sClient, objectName, stream.Pending)
 	helpers.AssertJobNotExists(t, k8sClient, objectName)
 }
@@ -183,7 +186,10 @@ func Test_UpdatePhase_Pending_To_Running_not_recreate_job(t *testing.T) {
 
 func Test_UpdatePhase_Pending_To_Scheduled_no_job(t *testing.T) {
 	// Arrange
-	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Pending).WithSchedule("* * * * *")
+	builder := v3.NewMockStreamDefinitionBuilder(objectName).
+		WithPhase(stream.Pending).
+		WithSchedule("* * * * *").
+		WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
 	mockCtrl := gomock.NewController(t)

--- a/tests/api_v1_test.go
+++ b/tests/api_v1_test.go
@@ -183,6 +183,9 @@ func Test_DynamicBackfillId(t *testing.T) {
 			envVars := job.ToObject().(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env
 			var backfillId string
 			for _, envVar := range envVars {
+				if envVar.Name == "STREAMCONTEXT__BACKFILL" {
+					require.Equal(t, "true", envVar.Value)
+				}
 				if envVar.Name == "STREAMCONTEXT__BACKFILL_ID" {
 					backfillId = envVar.ValueFrom.FieldRef.FieldPath
 					// The value should be set from the job's metadata.labels['job-name']


### PR DESCRIPTION
Part of non-streaming YAMLs

## Scope

Implemented:
- Added additional logs to the reconcile method
- Fixed logger initialization
- Fixed the condition when the stream with the CronJob backend creates BFR.
- Fixed the incorrect value of the STREAMCONTEXT__BACKFILL variable

Additional changes:
- Refactored `AwesomeClass`
- Removed deprecated `AnotherClass` and `get_awesomeness` from `AwesomeClass`

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.