### PR TITLE
Improve unit tests

### DIFF
--- a/services/controllers/stream/backend/cron_job/backend.go
+++ b/services/controllers/stream/backend/cron_job/backend.go
@@ -52,7 +52,7 @@ func NewCronJobBackend(client client.Client, jobBuilder stream.JobBuilder, event
 	}
 }
 
-func (c *Backend) SetupWithController(cache cache.Cache, scheme *runtime.Scheme, mapper meta.RESTMapper, controller controller.Controller, primaryGvk schema.GroupVersionKind) error {
+func (c *Backend) SetupWithController(cache cache.Cache, scheme *runtime.Scheme, mapper meta.RESTMapper, controller controller.Controller, primaryGvk schema.GroupVersionKind) error { // coverage-ignore
 	primaryResource := &unstructured.Unstructured{}
 	primaryResource.SetGroupVersionKind(primaryGvk)
 	return watchers.NewTypedSecondaryWatcherBuilder[*batchv1.CronJob]().
@@ -63,7 +63,7 @@ func (c *Backend) SetupWithController(cache cache.Cache, scheme *runtime.Scheme,
 		SetupWithController(controller, &batchv1.CronJob{})
 }
 
-func (c *Backend) Get(ctx context.Context, name client.ObjectKey) (stream.BackendResource, error) {
+func (c *Backend) Get(ctx context.Context, name client.ObjectKey) (stream.BackendResource, error) { // coverage-ignore
 	cj := &batchv1.CronJob{}
 	return c.ResourceReader.Get(ctx, name, cj, FromResource)
 }
@@ -92,7 +92,7 @@ func (c *Backend) Apply(ctx context.Context, definition stream.Definition, backf
 
 	logger.V(0).Info("Creating the cron job for the stream definition")
 	err := c.client.Get(ctx, types.NamespacedName{Name: object.Name, Namespace: object.Namespace}, object)
-	if client.IgnoreNotFound(err) != nil {
+	if client.IgnoreNotFound(err) != nil { // coverage-ignore
 		logger.V(0).Error(err, "failed to fetch cronjob")
 		return reconcile.Result{}, fmt.Errorf("failed to fetch cronjob: %w", err)
 	}

--- a/services/controllers/stream/tests/helpers/fake_client_resources_builder.go
+++ b/services/controllers/stream/tests/helpers/fake_client_resources_builder.go
@@ -39,8 +39,8 @@ func (b *FakeClientResourcesBuilder) Apply(fn func(*crfake.ClientBuilder)) *Fake
 // WithOutdatedJob seeds the fake client with a batch Job whose
 // configuration-hash annotation is set to "old-hash".
 func (b *FakeClientResourcesBuilder) WithOutdatedJob(n types.NamespacedName) *FakeClientResourcesBuilder {
-	return b.Apply(func(client2 *crfake.ClientBuilder) {
-		client2.WithObjects(&batchv1.Job{
+	return b.Apply(func(client *crfake.ClientBuilder) {
+		client.WithObjects(&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   n.Namespace,
 				Name:        n.Name,
@@ -53,8 +53,8 @@ func (b *FakeClientResourcesBuilder) WithOutdatedJob(n types.NamespacedName) *Fa
 // WithOutdatedCronJob seeds the fake client with a CronJob whose
 // configuration-hash annotation is set to "old-hash".
 func (b *FakeClientResourcesBuilder) WithOutdatedCronJob(n types.NamespacedName) *FakeClientResourcesBuilder {
-	return b.Apply(func(client2 *crfake.ClientBuilder) {
-		client2.WithObjects(&batchv1.CronJob{
+	return b.Apply(func(client *crfake.ClientBuilder) {
+		client.WithObjects(&batchv1.CronJob{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   n.Namespace,
 				Name:        n.Name,
@@ -66,8 +66,8 @@ func (b *FakeClientResourcesBuilder) WithOutdatedCronJob(n types.NamespacedName)
 
 // WithCompletedJob seeds the fake client with a batch Job in a completed state.
 func (b *FakeClientResourcesBuilder) WithCompletedJob(n types.NamespacedName) *FakeClientResourcesBuilder {
-	return b.Apply(func(client2 *crfake.ClientBuilder) {
-		client2.WithObjects(&batchv1.Job{
+	return b.Apply(func(client *crfake.ClientBuilder) {
+		client.WithObjects(&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   n.Namespace,
 				Name:        n.Name,
@@ -86,10 +86,9 @@ func (b *FakeClientResourcesBuilder) WithCompletedJob(n types.NamespacedName) *F
 // WithFailedJob seeds the fake client with a batch Job in a failed state
 // (failed twice with backoffLimit = 1).
 func (b *FakeClientResourcesBuilder) WithFailedJob(n types.NamespacedName) *FakeClientResourcesBuilder {
-	return b.Apply(func(client2 *crfake.ClientBuilder) {
-		backoffLimit := int32(1)
-		client2.WithObjects(&batchv1.Job{
-			Spec: batchv1.JobSpec{BackoffLimit: &backoffLimit},
+	return b.Apply(func(client *crfake.ClientBuilder) {
+		client.WithObjects(&batchv1.Job{
+			Spec: batchv1.JobSpec{BackoffLimit: new(int32(1))},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   n.Namespace,
 				Name:        n.Name,
@@ -109,8 +108,8 @@ func (b *FakeClientResourcesBuilder) WithFailedJob(n types.NamespacedName) *Fake
 // WithConsistentJob seeds the fake client with a batch Job whose
 // configuration-hash annotation matches the provided hash.
 func (b *FakeClientResourcesBuilder) WithConsistentJob(n types.NamespacedName, hash string) *FakeClientResourcesBuilder {
-	return b.Apply(func(client2 *crfake.ClientBuilder) {
-		client2.WithObjects(&batchv1.Job{
+	return b.Apply(func(client *crfake.ClientBuilder) {
+		client.WithObjects(&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   n.Namespace,
 				Name:        n.Name,
@@ -123,8 +122,8 @@ func (b *FakeClientResourcesBuilder) WithConsistentJob(n types.NamespacedName, h
 // WithConsistentCronJob seeds the fake client with a CronJob whose
 // configuration-hash annotation matches the provided hash.
 func (b *FakeClientResourcesBuilder) WithConsistentCronJob(n types.NamespacedName, hash string) *FakeClientResourcesBuilder {
-	return b.Apply(func(client2 *crfake.ClientBuilder) {
-		client2.WithObjects(&batchv1.CronJob{
+	return b.Apply(func(client *crfake.ClientBuilder) {
+		client.WithObjects(&batchv1.CronJob{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   n.Namespace,
 				Name:        n.Name,
@@ -137,12 +136,33 @@ func (b *FakeClientResourcesBuilder) WithConsistentCronJob(n types.NamespacedNam
 // WithBackfillRequest seeds the fake client with a BackfillRequest named
 // "backfill1" targeting the MockStreamDefinition identified by n.
 func (b *FakeClientResourcesBuilder) WithBackfillRequest(n types.NamespacedName) *FakeClientResourcesBuilder {
-	return b.Apply(func(client2 *crfake.ClientBuilder) {
-		client2.WithObjects(&v1.BackfillRequest{
+	return b.Apply(func(client *crfake.ClientBuilder) {
+		client.WithObjects(&v1.BackfillRequest{
 			ObjectMeta: metav1.ObjectMeta{Name: "backfill1", Namespace: n.Namespace},
 			Spec: v1.BackfillRequestSpec{
 				StreamClass: "MockStreamDefinition",
 				StreamId:    n.Name,
+			},
+		})
+	})
+}
+
+// WithStreamingJobTemplate seeds the fake client with a BackfillRequest named
+// "backfill1" targeting the MockStreamDefinition identified by n.
+func (b *FakeClientResourcesBuilder) WithStreamingJobTemplate(n types.NamespacedName) *FakeClientResourcesBuilder {
+	return b.Apply(func(client *crfake.ClientBuilder) {
+		client.WithObjects(&v1.StreamingJobTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: "template1", Namespace: n.Namespace},
+			Spec: batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main", Image: "busybox"},
+							},
+						},
+					},
+				},
 			},
 		})
 	})

--- a/services/controllers/stream/tests/helpers/fake_client_resources_builder.go
+++ b/services/controllers/stream/tests/helpers/fake_client_resources_builder.go
@@ -147,27 +147,6 @@ func (b *FakeClientResourcesBuilder) WithBackfillRequest(n types.NamespacedName)
 	})
 }
 
-// WithStreamingJobTemplate seeds the fake client with a BackfillRequest named
-// "backfill1" targeting the MockStreamDefinition identified by n.
-func (b *FakeClientResourcesBuilder) WithStreamingJobTemplate(n types.NamespacedName) *FakeClientResourcesBuilder {
-	return b.Apply(func(client *crfake.ClientBuilder) {
-		client.WithObjects(&v1.StreamingJobTemplate{
-			ObjectMeta: metav1.ObjectMeta{Name: "template1", Namespace: n.Namespace},
-			Spec: batchv1.Job{
-				Spec: batchv1.JobSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{Name: "main", Image: "busybox"},
-							},
-						},
-					},
-				},
-			},
-		})
-	})
-}
-
 // Build returns a single mutator function that applies all accumulated
 // resources to a *crfake.ClientBuilder. The result is computed on the first
 // call and the same function value is returned on subsequent calls.

--- a/services/controllers/stream/tests/helpers/v2/mock_stream_definition_builder.go
+++ b/services/controllers/stream/tests/helpers/v2/mock_stream_definition_builder.go
@@ -65,12 +65,11 @@ func (b *MockStreamDefinitionBuilder) WithName(n types.NamespacedName) *MockStre
 // WithSchedule configures the stream definition with a cron job backend using
 // the provided schedule, clearing the batch job backend.
 func (b *MockStreamDefinitionBuilder) WithSchedule(schedule string) *MockStreamDefinitionBuilder {
-	b.definition.Spec.ExecutionSettings.StreamingBackend = testv2.StreamingBackend{
-		BatchJobBackend: nil,
-		CronJobBackend: &testv2.CronJobBackend{
-			Schedule: schedule,
-		},
+	if b.definition.Spec.ExecutionSettings.StreamingBackend.CronJobBackend == nil {
+		b.definition.Spec.ExecutionSettings.StreamingBackend.CronJobBackend = &testv2.CronJobBackend{}
+		b.definition.Spec.ExecutionSettings.StreamingBackend.BatchJobBackend = nil
 	}
+	b.definition.Spec.ExecutionSettings.StreamingBackend.CronJobBackend.Schedule = schedule
 	return b
 }
 
@@ -79,6 +78,38 @@ func (b *MockStreamDefinitionBuilder) WithSchedule(schedule string) *MockStreamD
 func (b *MockStreamDefinitionBuilder) WithNoBackend() *MockStreamDefinitionBuilder {
 	b.definition.Spec.ExecutionSettings.StreamingBackend.BatchJobBackend = nil
 	b.definition.Spec.ExecutionSettings.StreamingBackend.CronJobBackend = nil
+	return b
+}
+
+// WithStreamingJobTemplateRef sets the job template reference for the batch job backend,
+// initializing the batch job backend if it is currently nil.
+func (b *MockStreamDefinitionBuilder) WithStreamingJobTemplateRef(name types.NamespacedName) *MockStreamDefinitionBuilder {
+	if b.definition.Spec.ExecutionSettings.StreamingBackend.BatchJobBackend == nil {
+		b.definition.Spec.ExecutionSettings.StreamingBackend.BatchJobBackend = &testv2.BatchJobBackend{}
+		b.definition.Spec.ExecutionSettings.StreamingBackend.CronJobBackend = nil
+	}
+	b.definition.Spec.ExecutionSettings.StreamingBackend.BatchJobBackend.JobTemplateRef.Name = name.Name
+	b.definition.Spec.ExecutionSettings.StreamingBackend.BatchJobBackend.JobTemplateRef.Namespace = name.Namespace
+	return b
+}
+
+// WithScheduledJobTemplateRef sets the job template reference for the batch job backend,
+// initializing the batch job backend if it is currently nil.
+func (b *MockStreamDefinitionBuilder) WithScheduledJobTemplateRef(name types.NamespacedName) *MockStreamDefinitionBuilder {
+	if b.definition.Spec.ExecutionSettings.StreamingBackend.CronJobBackend == nil {
+		b.definition.Spec.ExecutionSettings.StreamingBackend.CronJobBackend = &testv2.CronJobBackend{}
+		b.definition.Spec.ExecutionSettings.StreamingBackend.BatchJobBackend = nil
+	}
+	b.definition.Spec.ExecutionSettings.StreamingBackend.CronJobBackend.JobTemplateRef.Name = name.Name
+	b.definition.Spec.ExecutionSettings.StreamingBackend.CronJobBackend.JobTemplateRef.Namespace = name.Namespace
+	return b
+}
+
+// WithBackfillJobTemplateRef sets the job template reference for the batch job backend,
+// initializing the batch job backend if it is currently nil.
+func (b *MockStreamDefinitionBuilder) WithBackfillJobTemplateRef(name types.NamespacedName) *MockStreamDefinitionBuilder {
+	b.definition.Spec.ExecutionSettings.BackfillJobTemplateRef.Name = name.Name
+	b.definition.Spec.ExecutionSettings.BackfillJobTemplateRef.Namespace = name.Namespace
 	return b
 }
 

--- a/services/controllers/stream/tests/v1/stream_reconciler_test.go
+++ b/services/controllers/stream/tests/v1/stream_reconciler_test.go
@@ -107,7 +107,9 @@ func Test_UpdatePhase_Pending_To_Running_no_job(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -138,7 +140,9 @@ func Test_UpdatePhase_Pending_To_Running_recreate_job(t *testing.T) {
 		},
 	}
 
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -196,7 +200,9 @@ func Test_UpdatePhase_Pending_To_Scheduled_no_job(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -221,7 +227,9 @@ func Test_UpdatePhase_Pending_To_Backfilling_no_job(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -250,7 +258,9 @@ func Test_UpdatePhase_Pending_To_Backfilling_recreate_job(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -483,7 +493,9 @@ func Test_UpdatePhase_Backfilling_To_Backfilling_with_no_job(t *testing.T) {
 			},
 		},
 	}
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -513,7 +525,9 @@ func Test_UpdatePhase_Pending_To_Backfilling_with_schedule(t *testing.T) {
 			},
 		},
 	}
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -560,7 +574,9 @@ func Test_UpdatePhase_Backfilling_To_Suspended(t *testing.T) {
 			},
 		},
 	}
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -599,7 +615,9 @@ func Test_UpdatePhase_Backfilling_To_Running(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Namespace: objectName.Namespace, Name: objectName.Name}}
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -685,7 +703,9 @@ func Test_UpdatePhase_Failed_to_Backfilling(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -717,7 +737,9 @@ func Test_UpdatePhase_Scheduled_to_Scheduled_no_cron_job(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -757,7 +779,9 @@ func Test_UpdatePhase_Scheduled_to_Scheduled_recreate_cron_job(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -826,7 +850,9 @@ func Test_UpdatePhase_Scheduled_to_Suspended(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -846,7 +872,9 @@ func Test_UpdatePhase_Scheduled_to_Backfilling(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler, _ := createReconciler(k8sClient, &mockJob, mockCtrl)
+	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -859,12 +887,7 @@ func Test_UpdatePhase_Scheduled_to_Backfilling(t *testing.T) {
 	helpers.AssertBackfillRequestNotCompleted(t, k8sClient, objectName)
 }
 
-func createReconciler(k8sClient client.Client, mockJob *batchv1.Job, mockCtrl *gomock.Controller) (reconcile.Reconciler, *record.FakeRecorder) {
-	var jobBuilder *mocks.MockJobBuilder
-	if mockJob != nil {
-		jobBuilder = mocks.NewMockJobBuilder(mockCtrl)
-		jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockJob, nil).AnyTimes()
-	}
+func createReconciler(k8sClient client.Client, jobBuilder *mocks.MockJobBuilder, mockCtrl *gomock.Controller) (reconcile.Reconciler, *record.FakeRecorder) {
 	recorder := record.NewFakeRecorder(10)
 	gvk := schema.GroupVersionKind{Group: "streaming.sneaksanddata.com", Version: "v1", Kind: "MockStreamDefinition"}
 	mock := v2.MockStreamDefinition("name", "namespace")

--- a/services/controllers/stream/tests/v1/stream_reconciler_test.go
+++ b/services/controllers/stream/tests/v1/stream_reconciler_test.go
@@ -26,6 +26,9 @@ import (
 )
 
 var objectName = types.NamespacedName{Name: "stream1", Namespace: "default"}
+var streamingJobTemplateName = types.NamespacedName{Name: "streaming-template", Namespace: "default"}
+var backfillJobTemplateName = types.NamespacedName{Name: "backfill-template", Namespace: "default"}
+var batchJobTemplateName = types.NamespacedName{Name: "batch-template", Namespace: "default"}
 
 func Test_UpdatePhase_New_To_Suspended(t *testing.T) {
 	// Arrange
@@ -101,14 +104,17 @@ func Test_UpdatePhase_New_To_Pending_with_no_backend(t *testing.T) {
 
 func Test_UpdatePhase_Pending_To_Running_no_job(t *testing.T) {
 	// Arrange
-	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithSuspendedSpec(false).WithPhase(stream.Pending)
+	builder := v3.NewMockStreamDefinitionBuilder(objectName).
+		WithSuspendedSpec(false).
+		WithPhase(stream.Pending).
+		WithStreamingJobTemplateRef(streamingJobTemplateName)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(streamingJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -124,7 +130,10 @@ func Test_UpdatePhase_Pending_To_Running_no_job(t *testing.T) {
 
 func Test_UpdatePhase_Pending_To_Running_recreate_job(t *testing.T) {
 	// Arrange
-	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithSuspendedSpec(false).WithPhase(stream.Pending)
+	builder := v3.NewMockStreamDefinitionBuilder(objectName).
+		WithSuspendedSpec(false).
+		WithPhase(stream.Pending).
+		WithStreamingJobTemplateRef(streamingJobTemplateName)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithOutdatedJob(objectName))
 
 	mockCtrl := gomock.NewController(t)
@@ -141,7 +150,7 @@ func Test_UpdatePhase_Pending_To_Running_recreate_job(t *testing.T) {
 	}
 
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(streamingJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -193,7 +202,8 @@ func Test_UpdatePhase_Pending_To_Scheduled_no_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).
 		WithPhase(stream.Pending).
 		WithSchedule("* * * * *").
-		WithSuspendedSpec(false)
+		WithSuspendedSpec(false).
+		WithScheduledJobTemplateRef(batchJobTemplateName)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
 	mockCtrl := gomock.NewController(t)
@@ -201,7 +211,7 @@ func Test_UpdatePhase_Pending_To_Scheduled_no_job(t *testing.T) {
 
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(batchJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -220,7 +230,7 @@ func Test_UpdatePhase_Pending_To_Scheduled_no_job(t *testing.T) {
 
 func Test_UpdatePhase_Pending_To_Backfilling_no_job(t *testing.T) {
 	// Arrange
-	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Pending)
+	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Pending).WithBackfillJobTemplateRef(batchJobTemplateName)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
 	mockCtrl := gomock.NewController(t)
@@ -228,7 +238,7 @@ func Test_UpdatePhase_Pending_To_Backfilling_no_job(t *testing.T) {
 
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(batchJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -243,7 +253,7 @@ func Test_UpdatePhase_Pending_To_Backfilling_no_job(t *testing.T) {
 
 func Test_UpdatePhase_Pending_To_Backfilling_recreate_job(t *testing.T) {
 	// Arrange
-	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Pending)
+	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Pending).WithBackfillJobTemplateRef(backfillJobTemplateName)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName).WithOutdatedJob(objectName))
 
 	mockJob := batchv1.Job{
@@ -259,7 +269,7 @@ func Test_UpdatePhase_Pending_To_Backfilling_recreate_job(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(backfillJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -478,7 +488,10 @@ func Test_UpdatePhase_Backfilling_To_Backfilling_with_job_running(t *testing.T) 
 
 func Test_UpdatePhase_Backfilling_To_Backfilling_with_no_job(t *testing.T) {
 	// Arrange
-	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(false)
+	builder := v3.NewMockStreamDefinitionBuilder(objectName).
+		WithPhase(stream.Backfilling).
+		WithSuspendedSpec(false).
+		WithBackfillJobTemplateRef(backfillJobTemplateName)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
 	mockCtrl := gomock.NewController(t)
@@ -494,7 +507,7 @@ func Test_UpdatePhase_Backfilling_To_Backfilling_with_no_job(t *testing.T) {
 		},
 	}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(backfillJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -510,7 +523,11 @@ func Test_UpdatePhase_Backfilling_To_Backfilling_with_no_job(t *testing.T) {
 
 func Test_UpdatePhase_Pending_To_Backfilling_with_schedule(t *testing.T) {
 	// Arrange
-	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Pending).WithSuspendedSpec(false).WithSchedule("* * * * *")
+	builder := v3.NewMockStreamDefinitionBuilder(objectName).
+		WithPhase(stream.Pending).
+		WithSuspendedSpec(false).
+		WithSchedule("* * * * *").
+		WithBackfillJobTemplateRef(backfillJobTemplateName)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
 	mockCtrl := gomock.NewController(t)
@@ -526,7 +543,7 @@ func Test_UpdatePhase_Pending_To_Backfilling_with_schedule(t *testing.T) {
 		},
 	}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(backfillJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -575,7 +592,7 @@ func Test_UpdatePhase_Backfilling_To_Suspended(t *testing.T) {
 		},
 	}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(streamingJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -616,7 +633,7 @@ func Test_UpdatePhase_Backfilling_To_Running(t *testing.T) {
 
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Namespace: objectName.Namespace, Name: objectName.Name}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(streamingJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -697,14 +714,17 @@ func Test_UpdatePhase_Failed_to_Suspended_with_BackfillRequest(t *testing.T) {
 
 func Test_UpdatePhase_Failed_to_Backfilling(t *testing.T) {
 	// Arrange
-	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Failed).WithSuspendedSpec(false)
+	builder := v3.NewMockStreamDefinitionBuilder(objectName).
+		WithPhase(stream.Failed).
+		WithSuspendedSpec(false).
+		WithBackfillJobTemplateRef(backfillJobTemplateName)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(backfillJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -722,7 +742,9 @@ func Test_UpdatePhase_Scheduled_to_Scheduled_no_cron_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).
 		WithPhase(stream.Scheduled).
 		WithSuspendedSpec(false).
-		WithSchedule("* * * * *")
+		WithSchedule("* * * * *").
+		WithScheduledJobTemplateRef(batchJobTemplateName)
+
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
 	u, err := helpers.GetStreamDefinitionUnstructured(t.Context(), k8sClient, objectName, helpers.GroupVersionKindV2)
@@ -738,7 +760,7 @@ func Test_UpdatePhase_Scheduled_to_Scheduled_no_cron_job(t *testing.T) {
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(batchJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -759,7 +781,8 @@ func Test_UpdatePhase_Scheduled_to_Scheduled_recreate_cron_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).
 		WithPhase(stream.Scheduled).
 		WithSuspendedSpec(false).
-		WithSchedule("* * * * *")
+		WithSchedule("* * * * *").
+		WithScheduledJobTemplateRef(batchJobTemplateName)
 	resourceBuilder := helpers.NewFakeClientResourcesBuilder().WithOutdatedCronJob(objectName)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, resourceBuilder)
 
@@ -780,7 +803,7 @@ func Test_UpdatePhase_Scheduled_to_Scheduled_recreate_cron_job(t *testing.T) {
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(batchJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -851,7 +874,7 @@ func Test_UpdatePhase_Scheduled_to_Suspended(t *testing.T) {
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(streamingJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act
@@ -873,7 +896,7 @@ func Test_UpdatePhase_Scheduled_to_Backfilling(t *testing.T) {
 	defer mockCtrl.Finish()
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mockJob, nil).AnyTimes()
+	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(streamingJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
 	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
 
 	// Act


### PR DESCRIPTION
This PR improves unit testing

## Scope

Implemented:
- The reconciler state machine tests now validates which template reference is being used to create a backend resource.
- Some trivial methods are removed from coverage.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.