### PR TITLE
Improve backfill docs and behavior

### DIFF
--- a/docs/user_scenarios.md
+++ b/docs/user_scenarios.md
@@ -56,3 +56,19 @@ This behaviour will be improved once [lock-on](https://github.com/SneaksAndData/
 ## What happens if I delete a backfill request while the backfill job is running?
 If you delete a backfill request while the backfill job is running, the operator will stop the backfill job 
 and restart it in the streaming mode.
+
+## What happens if I suspend a stream while the backfill job is running?
+If you suspend a stream while the backfill job is running, the operator will stop the backfill and **will not** mark
+the backfill request as completed. The backfill request will remain in the active state and you can resume it later by
+unsuspending the stream. This can be useful if the plugin supports the resumable backfill (see the documentation of the 
+plugin you are using for more details).
+
+## What should I do if the backfill job fails?
+If the backfill job fails, you can check the logs of the backfill job pod to see what went wrong. You can pause the
+stream by setting `spec.suspended` to `true`, fix the issue, and then resume the stream by setting `spec.suspended`
+to `false`. If you need to re-run the backfill, you **should** delete the existing backfill request and create a new one.
+
+## What if the backfill job does not have enough resources to complete?
+If the backfill job does not have enough resources to complete, you should suspend the stream by setting
+`spec.suspended` to `true`, and then change the backfillJobTemplate in the stream definition to request more resources.
+After that, you can resume the stream by setting `spec.suspended` to `false`.

--- a/services/controllers/stream/backend/job/backfill_backend.go
+++ b/services/controllers/stream/backend/job/backfill_backend.go
@@ -81,6 +81,8 @@ func (b *BackfillBackend) Get(ctx context.Context, name types.NamespacedName) (s
 	return FromResource(obj)
 }
 
+// Remove removes the backfill job. This method DOES NOT mark the backfill request as completed.
+// It is the responsibility of the caller to mark the backfill request as completed if necessary.
 func (b *BackfillBackend) Remove(ctx context.Context, definition stream.Definition, nextPhase stream.Phase, eventFunc controllers.EventFunc) (reconcile.Result, error) {
 	object := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -92,23 +94,6 @@ func (b *BackfillBackend) Remove(ctx context.Context, definition stream.Definiti
 	_, err := b.BaseResourceManager.Remove(ctx, object, nil)
 	if err != nil { // coverage-ignore
 		return reconcile.Result{}, fmt.Errorf("failed to remove job: %w", err)
-	}
-
-	request, err := b.GetBackfillRequest(ctx, definition)
-	if err != nil { // coverage-ignore
-		return reconcile.Result{}, fmt.Errorf("failed to get backfill request: %w", err)
-	}
-
-	if request != nil {
-		request.Spec.Completed = true
-		err := b.client.Update(ctx, request)
-		if err != nil { // coverage-ignore
-			return reconcile.Result{}, err
-		}
-		err = b.client.Status().Update(ctx, request)
-		if err != nil { // coverage-ignore
-			return reconcile.Result{}, err
-		}
 	}
 
 	return b.statusManager.UpdateStreamPhase(ctx, definition, nil, nextPhase, eventFunc)
@@ -145,6 +130,30 @@ func (b *BackfillBackend) GetBackfillRequest(ctx context.Context, definition str
 	}
 
 	return nil, nil
+}
+
+// Complete marks the backfill request as completed. It does not remove the backfill job. It is the responsibility of
+// the caller to remove the backfill job if necessary.
+func (b *BackfillBackend) Complete(ctx context.Context, definition stream.Definition, nextPhase stream.Phase, _ *v1.StreamClass, eventFunc controllers.EventFunc) (reconcile.Result, error) {
+
+	request, err := b.GetBackfillRequest(ctx, definition)
+	if err != nil { // coverage-ignore
+		return reconcile.Result{}, fmt.Errorf("failed to get backfill request: %w", err)
+	}
+
+	if request != nil {
+		request.Spec.Completed = true
+		err := b.client.Update(ctx, request)
+		if err != nil { // coverage-ignore
+			return reconcile.Result{}, err
+		}
+		err = b.client.Status().Update(ctx, request)
+		if err != nil { // coverage-ignore
+			return reconcile.Result{}, err
+		}
+	}
+
+	return b.statusManager.UpdateStreamPhase(ctx, definition, request, nextPhase, eventFunc)
 }
 
 func (b *BackfillBackend) getLogger(_ context.Context, request types.NamespacedName) klog.Logger { // coverage-ignore

--- a/services/controllers/stream/backfill_backend_resource_manager.go
+++ b/services/controllers/stream/backfill_backend_resource_manager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	v1 "github.com/SneaksAndData/arcane-operator/pkg/apis/streaming/v1"
+	"github.com/SneaksAndData/arcane-operator/services/controllers"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type BackfillBackendResourceManager interface {
@@ -11,4 +13,8 @@ type BackfillBackendResourceManager interface {
 
 	// GetBackfillRequest returns the current backfill request associated with the given stream definition, if any.
 	GetBackfillRequest(ctx context.Context, definition Definition) (*v1.BackfillRequest, error)
+
+	// Complete handles the completion of a backfill request for the given stream definition,
+	// transitioning to the next phase and invoking the provided event function.
+	Complete(ctx context.Context, definition Definition, nextPhase Phase, streamClass *v1.StreamClass, eventFunc controllers.EventFunc) (reconcile.Result, error)
 }

--- a/services/controllers/stream/stream_reconciler.go
+++ b/services/controllers/stream/stream_reconciler.go
@@ -291,6 +291,11 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 		})
 
 	case phase == Backfilling && backfillRequest == nil:
+		_, err := s.backfillBackendResourceManager.Complete(ctx, definition, Pending, s.streamClass, nil)
+		if err != nil {
+			logger.Error(err, "failed to remove backfill job")
+			return reconcile.Result{}, err
+		}
 		return s.backfillBackendResourceManager.Remove(ctx, definition, Pending, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),
 				"Normal",
@@ -307,6 +312,11 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 		})
 
 	case phase == Backfilling && job.IsCompleted():
+		_, err := s.backfillBackendResourceManager.Complete(ctx, definition, Pending, s.streamClass, nil)
+		if err != nil {
+			logger.Error(err, "failed to remove backfill job")
+			return reconcile.Result{}, err
+		}
 		return s.backfillBackendResourceManager.Remove(ctx, definition, Pending, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),
 				"Normal",

--- a/services/controllers/stream/stream_reconciler.go
+++ b/services/controllers/stream/stream_reconciler.go
@@ -170,14 +170,6 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 				"The stream was suspended")
 		})
 
-	case phase == Failed && !definition.Suspended() && backfillRequest != nil:
-		return s.backendResourceManagers[definition.GetBackend()].Apply(ctx, definition, backfillRequest, Backfilling, s.streamClass, func() {
-			s.eventRecorder.Eventf(definition.ToUnstructured(),
-				"Normal",
-				"BackfillRequested",
-				"Backfill was requested for the new stream definition: %s", definition.NamespacedName().Name)
-		})
-
 	case phase == Failed:
 		return s.backendResourceManagers[definition.GetBackend()].Remove(ctx, definition, Failed, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),

--- a/services/controllers/stream/tests/backfill_backend_resource_manager_test.go
+++ b/services/controllers/stream/tests/backfill_backend_resource_manager_test.go
@@ -82,7 +82,7 @@ func Test_Remove_WithBackfillRequest(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	helpers.AssertBackfillRequestCompleted(t, k8sClient, objectName)
+	helpers.AssertBackfillRequestNotCompleted(t, k8sClient, objectName)
 }
 
 func Test_Apply(t *testing.T) {

--- a/services/controllers/stream/tests/v0/stream_reconciler_test.go
+++ b/services/controllers/stream/tests/v0/stream_reconciler_test.go
@@ -421,7 +421,7 @@ func Test_UpdatePhase_Backfilling_To_Suspended(t *testing.T) {
 	// Assert
 	assertStreamDefinitionPhase(t, k8sClient, objectName, stream.Suspended)
 	assertJobNotExists(t, k8sClient, objectName)
-	assertBackfillRequestCompleted(t, k8sClient)
+	assertBackfillRequestNotCompleted(t, k8sClient)
 }
 
 func Test_UpdatePhase_Backfilling_Job_Failed(t *testing.T) {
@@ -439,7 +439,7 @@ func Test_UpdatePhase_Backfilling_Job_Failed(t *testing.T) {
 	// Assert
 	assertStreamDefinitionPhase(t, k8sClient, objectName, stream.Failed)
 	assertJobNotExists(t, k8sClient, objectName)
-	assertBackfillRequestCompleted(t, k8sClient)
+	assertBackfillRequestNotCompleted(t, k8sClient)
 }
 
 func Test_UpdatePhase_Backfilling_To_Running(t *testing.T) {
@@ -527,7 +527,7 @@ func Test_UpdatePhase_Failed_to_Suspended_with_BackfillRequest(t *testing.T) {
 
 	// Assert
 	assertStreamDefinitionPhase(t, k8sClient, objectName, stream.Suspended)
-	assertBackfillRequestCompleted(t, k8sClient)
+	assertBackfillRequestNotCompleted(t, k8sClient)
 }
 
 func Test_UpdatePhase_Failed_to_Backfilling(t *testing.T) {

--- a/services/controllers/stream/tests/v0/stream_reconciler_test.go
+++ b/services/controllers/stream/tests/v0/stream_reconciler_test.go
@@ -530,27 +530,6 @@ func Test_UpdatePhase_Failed_to_Suspended_with_BackfillRequest(t *testing.T) {
 	assertBackfillRequestNotCompleted(t, k8sClient)
 }
 
-func Test_UpdatePhase_Failed_to_Backfilling(t *testing.T) {
-	// Arrange
-	builder := v4.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Failed).WithSuspendedSpec(false)
-	resourceBuilder := helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName)
-	k8sClient := helpers.SetupClientFromBuilders(builder, nil, resourceBuilder)
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	reconciler := createReconciler(k8sClient, &mockJob, mockCtrl)
-
-	// Act
-	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
-	require.NoError(t, err)
-	require.Equal(t, result, reconcile.Result{})
-
-	// Assert
-	assertStreamDefinitionPhase(t, k8sClient, objectName, stream.Backfilling)
-	assertBackfillRequestNotCompleted(t, k8sClient)
-}
-
 func createReconciler(k8sClient client.Client, mockJob *batchv1.Job, mockCtrl *gomock.Controller) reconcile.Reconciler {
 	var jobBuilder *mocks.MockJobBuilder
 	if mockJob != nil {

--- a/services/controllers/stream/tests/v1/stream_reconciler_test.go
+++ b/services/controllers/stream/tests/v1/stream_reconciler_test.go
@@ -713,31 +713,6 @@ func Test_UpdatePhase_Failed_to_Suspended_with_BackfillRequest(t *testing.T) {
 	helpers.AssertBackfillRequestNotCompleted(t, k8sClient, objectName)
 }
 
-func Test_UpdatePhase_Failed_to_Backfilling(t *testing.T) {
-	// Arrange
-	builder := v3.NewMockStreamDefinitionBuilder(objectName).
-		WithPhase(stream.Failed).
-		WithSuspendedSpec(false).
-		WithBackfillJobTemplateRef(backfillJobTemplateName)
-	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
-	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
-	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(backfillJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder)
-
-	// Act
-	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
-	require.NoError(t, err)
-	require.Equal(t, result, reconcile.Result{})
-
-	// Assert
-	helpers.AssertStreamDefinitionPhase(t, k8sClient, objectName, stream.Backfilling)
-	helpers.AssertBackfillRequestNotCompleted(t, k8sClient, objectName)
-}
-
 func Test_UpdatePhase_Scheduled_to_Scheduled_no_cron_job(t *testing.T) {
 	// Arrange
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).

--- a/services/controllers/stream/tests/v1/stream_reconciler_test.go
+++ b/services/controllers/stream/tests/v1/stream_reconciler_test.go
@@ -33,7 +33,7 @@ var batchJobTemplateName = types.NamespacedName{Name: "batch-template", Namespac
 func Test_UpdatePhase_New_To_Suspended(t *testing.T) {
 	// Arrange
 	k8sClient := helpers.SetupClientFromBuilders(nil, v3.NewMockStreamDefinitionBuilder(objectName), nil)
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -49,7 +49,7 @@ func Test_UpdatePhase_New_To_Pending(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -66,7 +66,7 @@ func Test_UpdatePhase_New_To_Pending_with_schedule(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithSuspendedSpec(false).WithSchedule("* * * * *")
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -87,7 +87,7 @@ func Test_UpdatePhase_New_To_Pending_with_no_backend(t *testing.T) {
 
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler, recorder := createReconciler(k8sClient, nil, nil)
+	reconciler, recorder := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -115,7 +115,7 @@ func Test_UpdatePhase_Pending_To_Running_no_job(t *testing.T) {
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(streamingJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -151,7 +151,7 @@ func Test_UpdatePhase_Pending_To_Running_recreate_job(t *testing.T) {
 
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(streamingJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -184,7 +184,7 @@ func Test_UpdatePhase_Pending_To_Running_not_recreate_job(t *testing.T) {
 	// Create the fake client and resources
 	resources := helpers.NewFakeClientResourcesBuilder().WithConsistentJob(objectName, definitionHash)
 	k8sClient = helpers.SetupClientFromBuilders(nil, streamDefinitionBuilder, resources)
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -212,7 +212,7 @@ func Test_UpdatePhase_Pending_To_Scheduled_no_job(t *testing.T) {
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(batchJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -239,7 +239,7 @@ func Test_UpdatePhase_Pending_To_Backfilling_no_job(t *testing.T) {
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(batchJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -270,7 +270,7 @@ func Test_UpdatePhase_Pending_To_Backfilling_recreate_job(t *testing.T) {
 
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(backfillJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -288,7 +288,7 @@ func Test_UpdatePhase_Running_To_Suspended_no_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Running).WithSuspendedSpec(true)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -304,7 +304,7 @@ func Test_UpdatePhase_Running_To_Suspended_stop_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Running).WithSuspendedSpec(true)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName).WithOutdatedJob(objectName))
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -321,7 +321,7 @@ func Test_UpdatePhase_Running_To_Suspended_to_Pending(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -337,7 +337,7 @@ func Test_UpdatePhase_Running_To_Suspended_to_Pending_With_BFR(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended).WithSuspendedSpec(true)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -353,7 +353,7 @@ func Test_UpdatePhase_Running_To_Pending_with_schedule(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Running).WithSuspendedSpec(false).WithSchedule("* * * * *")
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithOutdatedJob(objectName))
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -370,7 +370,7 @@ func Test_UpdatePhase_Running_with_BackfillRequest_no_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Running).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -386,7 +386,7 @@ func Test_UpdatePhase_Suspended_with_BackfillRequest(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -402,7 +402,7 @@ func Test_UpdatePhase_Suspended_without_BackfillRequest_without_job(t *testing.T
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -419,7 +419,7 @@ func Test_UpdatePhase_Suspended_without_BackfillRequest_with_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithOutdatedJob(objectName))
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -433,10 +433,11 @@ func Test_UpdatePhase_Suspended_without_BackfillRequest_with_job(t *testing.T) {
 
 func Test_UpdatePhase_Backfilling_To_Pending_with_job_completed(t *testing.T) {
 	// Arrange
-	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(false)
-	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName).WithCompletedJob(objectName))
+	streamResource := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(false)
+	otherResources := helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName).WithCompletedJob(objectName)
+	k8sClient := helpers.SetupClientFromBuilders(nil, streamResource, otherResources)
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -454,7 +455,7 @@ func Test_UpdatePhase_Backfilling_To_Pending_with_deleted_bfr(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithOutdatedJob(objectName))
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	helpers.AssertJobExists(t, k8sClient, objectName)
 
@@ -473,7 +474,7 @@ func Test_UpdatePhase_Backfilling_To_Backfilling_with_job_running(t *testing.T) 
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithOutdatedJob(objectName).WithBackfillRequest(objectName))
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -508,7 +509,7 @@ func Test_UpdatePhase_Backfilling_To_Backfilling_with_no_job(t *testing.T) {
 	}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(backfillJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -544,7 +545,7 @@ func Test_UpdatePhase_Pending_To_Backfilling_with_schedule(t *testing.T) {
 	}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(backfillJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -562,7 +563,7 @@ func Test_UpdatePhase_Backfilling_To_Pending_with_schedule(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(false).WithSchedule("* * * * *")
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithOutdatedJob(objectName))
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -576,8 +577,11 @@ func Test_UpdatePhase_Backfilling_To_Pending_with_schedule(t *testing.T) {
 
 func Test_UpdatePhase_Backfilling_To_Suspended(t *testing.T) {
 	// Arrange
-	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(true)
-	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
+	streamResource := v3.NewMockStreamDefinitionBuilder(objectName).
+		WithPhase(stream.Backfilling).
+		WithSuspendedSpec(true)
+	otherResources := helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName)
+	k8sClient := helpers.SetupClientFromBuilders(nil, streamResource, otherResources)
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -586,14 +590,11 @@ func Test_UpdatePhase_Backfilling_To_Suspended(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: objectName.Namespace,
 			Name:      objectName.Name,
-			Annotations: map[string]string{
-				"configuration-hash": "new-hash",
-			},
 		},
 	}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(streamingJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -603,14 +604,14 @@ func Test_UpdatePhase_Backfilling_To_Suspended(t *testing.T) {
 	// Assert
 	helpers.AssertStreamDefinitionPhase(t, k8sClient, objectName, stream.Suspended)
 	helpers.AssertJobNotExists(t, k8sClient, objectName)
-	helpers.AssertBackfillRequestCompleted(t, k8sClient, objectName)
+	helpers.AssertBackfillRequestNotCompleted(t, k8sClient, objectName)
 }
 
 func Test_UpdatePhase_Backfilling_Job_Failed(t *testing.T) {
 	// Arrange
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Backfilling).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName).WithFailedJob(objectName))
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -620,7 +621,7 @@ func Test_UpdatePhase_Backfilling_Job_Failed(t *testing.T) {
 	// Assert
 	helpers.AssertStreamDefinitionPhase(t, k8sClient, objectName, stream.Failed)
 	helpers.AssertJobNotExists(t, k8sClient, objectName)
-	helpers.AssertBackfillRequestCompleted(t, k8sClient, objectName)
+	helpers.AssertBackfillRequestNotCompleted(t, k8sClient, objectName)
 }
 
 func Test_UpdatePhase_Backfilling_To_Running(t *testing.T) {
@@ -634,7 +635,7 @@ func Test_UpdatePhase_Backfilling_To_Running(t *testing.T) {
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Namespace: objectName.Namespace, Name: objectName.Name}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(streamingJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -651,7 +652,7 @@ func Test_UpdatePhase_Failed_to_Failed(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Failed)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithFailedJob(objectName))
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -668,7 +669,7 @@ func Test_UpdatePhase_Failed_to_Failed_without_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Failed).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -684,7 +685,7 @@ func Test_UpdatePhase_Failed_to_Suspended_without_job(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Failed).WithSuspendedSpec(true)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, nil)
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -700,7 +701,7 @@ func Test_UpdatePhase_Failed_to_Suspended_with_BackfillRequest(t *testing.T) {
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Failed).WithSuspendedSpec(true)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -709,7 +710,7 @@ func Test_UpdatePhase_Failed_to_Suspended_with_BackfillRequest(t *testing.T) {
 
 	// Assert
 	helpers.AssertStreamDefinitionPhase(t, k8sClient, objectName, stream.Suspended)
-	helpers.AssertBackfillRequestCompleted(t, k8sClient, objectName)
+	helpers.AssertBackfillRequestNotCompleted(t, k8sClient, objectName)
 }
 
 func Test_UpdatePhase_Failed_to_Backfilling(t *testing.T) {
@@ -725,7 +726,7 @@ func Test_UpdatePhase_Failed_to_Backfilling(t *testing.T) {
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(backfillJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -761,7 +762,7 @@ func Test_UpdatePhase_Scheduled_to_Scheduled_no_cron_job(t *testing.T) {
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(batchJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -804,7 +805,7 @@ func Test_UpdatePhase_Scheduled_to_Scheduled_recreate_cron_job(t *testing.T) {
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(batchJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -847,7 +848,7 @@ func Test_UpdatePhase_Scheduled_to_Scheduled_not_recreate_cron_job(t *testing.T)
 	err = k8sClient.Get(t.Context(), objectName, oldJob)
 	require.NoError(t, err)
 
-	reconciler, _ := createReconciler(k8sClient, nil, nil)
+	reconciler, _ := createReconciler(k8sClient, nil)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -875,7 +876,7 @@ func Test_UpdatePhase_Scheduled_to_Suspended(t *testing.T) {
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(streamingJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -897,7 +898,7 @@ func Test_UpdatePhase_Scheduled_to_Backfilling(t *testing.T) {
 	mockJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: objectName.Name, Namespace: objectName.Namespace}}
 	jobBuilder := mocks.NewMockJobBuilder(mockCtrl)
 	jobBuilder.EXPECT().BuildJob(gomock.Any(), gomock.Eq(streamingJobTemplateName), gomock.Any()).Return(&mockJob, nil).AnyTimes()
-	reconciler, _ := createReconciler(k8sClient, jobBuilder, mockCtrl)
+	reconciler, _ := createReconciler(k8sClient, jobBuilder)
 
 	// Act
 	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
@@ -910,7 +911,7 @@ func Test_UpdatePhase_Scheduled_to_Backfilling(t *testing.T) {
 	helpers.AssertBackfillRequestNotCompleted(t, k8sClient, objectName)
 }
 
-func createReconciler(k8sClient client.Client, jobBuilder *mocks.MockJobBuilder, mockCtrl *gomock.Controller) (reconcile.Reconciler, *record.FakeRecorder) {
+func createReconciler(k8sClient client.Client, jobBuilder *mocks.MockJobBuilder) (reconcile.Reconciler, *record.FakeRecorder) {
 	recorder := record.NewFakeRecorder(10)
 	gvk := schema.GroupVersionKind{Group: "streaming.sneaksanddata.com", Version: "v1", Kind: "MockStreamDefinition"}
 	mock := v2.MockStreamDefinition("name", "namespace")


### PR DESCRIPTION
Resolves #299
Resolves https://github.com/SneaksAndData/arcane-operator/issues/300

- Added the documentation describing the backfill suspend documentation.
- Changed the backfill behavior to support suspending the backfill process without completion of the BFR
- Removed unused parameter in `createReconciler` function in tests/v1
- Removed an ability to transit from Failed to Backfilling by creating a backfill request.

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.