### PR TITLE
Fix the incorrect backfill suspend behavior

### DIFF
--- a/docs/user_scenarios.md
+++ b/docs/user_scenarios.md
@@ -18,8 +18,11 @@ To suspend the stream, you need to update the stream custom resource (CR) and se
 This will stop the streaming job and prevent it from processing any new data.
 
 ## I want to start backfill for an existing stream
-To start backfill for an existing stream, you need to create a backfill request custom resource (CR) that references the stream.
-The backfill request will be picked up by the operator, which will create a Kubernetes job to run the backfill process.
+To start backfill for an existing stream, you need to create a backfill request custom resource (CR) that references 
+the stream. If the stream was in a `Running` phase, the backfill request will be picked up by the operator, which will 
+create a Kubernetes job to run the backfill process. If the stream was in a `Suspended` phase, you should unsuspend the 
+stream first to start the backfill process. If the stream was in a `Failed` phase, you should fix the issue that caused
+the failure first, and then unsuspend the stream.
 
 Example backfill request:
 ```yaml

--- a/services/controllers/stream/stream_reconciler.go
+++ b/services/controllers/stream/stream_reconciler.go
@@ -250,7 +250,15 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 				"The streaming job for stream %s is continuing", definition.NamespacedName().Name)
 		})
 
-	case phase == Suspended && backfillRequest != nil:
+	case phase == Suspended && backfillRequest != nil && definition.Suspended():
+		return s.backendResourceManagers[definition.GetBackend()].NoOp(ctx, definition, backfillRequest, Suspended, func() {
+			s.eventRecorder.Eventf(definition.ToUnstructured(),
+				"Normal",
+				"BackfillRequested",
+				"A backfill requested for suspended stream %s", definition.NamespacedName().Name)
+		})
+
+	case phase == Suspended && backfillRequest != nil && !definition.Suspended():
 		return s.backendResourceManagers[definition.GetBackend()].NoOp(ctx, definition, backfillRequest, Pending, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),
 				"Normal",

--- a/services/controllers/stream/stream_reconciler.go
+++ b/services/controllers/stream/stream_reconciler.go
@@ -254,8 +254,8 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 		return s.backendResourceManagers[definition.GetBackend()].NoOp(ctx, definition, backfillRequest, Suspended, func() {
 			s.eventRecorder.Eventf(definition.ToUnstructured(),
 				"Normal",
-				"BackfillRequested",
-				"A backfill requested for suspended stream %s", definition.NamespacedName().Name)
+				"BackfillSuspended",
+				"A backfill was suspended for suspended stream %s", definition.NamespacedName().Name)
 		})
 
 	case phase == Suspended && backfillRequest != nil && !definition.Suspended():
@@ -263,7 +263,7 @@ func (s *streamReconciler) moveFsm(ctx context.Context, definition Definition, j
 			s.eventRecorder.Eventf(definition.ToUnstructured(),
 				"Normal",
 				"BackfillRequested",
-				"A backfill requested for suspended stream %s", definition.NamespacedName().Name)
+				"A backfill was requested for suspended stream %s", definition.NamespacedName().Name)
 		})
 
 	case phase == Suspended && backfillRequest == nil && definition.Suspended():

--- a/services/controllers/stream/tests/v0/stream_reconciler_test.go
+++ b/services/controllers/stream/tests/v0/stream_reconciler_test.go
@@ -244,9 +244,25 @@ func Test_UpdatePhase_Running_To_Suspended_to_Pending(t *testing.T) {
 	assertStreamDefinitionPhase(t, k8sClient, objectName, stream.Pending)
 }
 
-func Test_UpdatePhase_Running_To_Suspended_to_Pending_With_BFR(t *testing.T) {
+func Test_UpdatePhase_Suspended_To_Suspended_to_Suspended_With_BFR(t *testing.T) {
 	// Arrange
 	builder := v4.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended).WithSuspendedSpec(true)
+	resourceBuilder := helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName)
+	k8sClient := helpers.SetupClientFromBuilders(builder, nil, resourceBuilder)
+	reconciler := createReconciler(k8sClient, nil, nil)
+
+	// Act
+	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
+	require.NoError(t, err)
+	require.Equal(t, result, reconcile.Result{})
+
+	// Assert
+	assertStreamDefinitionPhase(t, k8sClient, objectName, stream.Suspended)
+}
+
+func Test_UpdatePhase_Suspended_To_Pending_to_Pending_With_BFR(t *testing.T) {
+	// Arrange
+	builder := v4.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended).WithSuspendedSpec(false)
 	resourceBuilder := helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName)
 	k8sClient := helpers.SetupClientFromBuilders(builder, nil, resourceBuilder)
 	reconciler := createReconciler(k8sClient, nil, nil)
@@ -289,7 +305,7 @@ func Test_UpdatePhase_Suspended_with_BackfillRequest(t *testing.T) {
 	require.Equal(t, result, reconcile.Result{})
 
 	// Assert
-	assertStreamDefinitionPhase(t, k8sClient, objectName, stream.Pending)
+	assertStreamDefinitionPhase(t, k8sClient, objectName, stream.Suspended)
 }
 
 func Test_UpdatePhase_Suspended_without_BackfillRequest_without_job(t *testing.T) {

--- a/services/controllers/stream/tests/v1/stream_reconciler_test.go
+++ b/services/controllers/stream/tests/v1/stream_reconciler_test.go
@@ -332,9 +332,25 @@ func Test_UpdatePhase_Running_To_Suspended_to_Pending(t *testing.T) {
 	helpers.AssertStreamDefinitionPhase(t, k8sClient, objectName, stream.Pending)
 }
 
-func Test_UpdatePhase_Running_To_Suspended_to_Pending_With_BFR(t *testing.T) {
+func Test_UpdatePhase_Suspended_To_Suspended_to_Pending_With_BFR(t *testing.T) {
 	// Arrange
 	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended).WithSuspendedSpec(true)
+	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
+
+	reconciler, _ := createReconciler(k8sClient, nil)
+
+	// Act
+	result, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: objectName})
+	require.NoError(t, err)
+	require.Equal(t, result, reconcile.Result{})
+
+	// Assert
+	helpers.AssertStreamDefinitionPhase(t, k8sClient, objectName, stream.Suspended)
+}
+
+func Test_UpdatePhase_Suspended_To_Pending_to_Pending_With_BFR(t *testing.T) {
+	// Arrange
+	builder := v3.NewMockStreamDefinitionBuilder(objectName).WithPhase(stream.Suspended).WithSuspendedSpec(false)
 	k8sClient := helpers.SetupClientFromBuilders(nil, builder, helpers.NewFakeClientResourcesBuilder().WithBackfillRequest(objectName))
 
 	reconciler, _ := createReconciler(k8sClient, nil)


### PR DESCRIPTION
Fixes #302

## Scope

Implemented:
- Fixes an error when if the backfilling job is suspended, the stream definition transits to a Pending phase which makes impossible to suspend a backfilling job.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.